### PR TITLE
Add engines build workflow

### DIFF
--- a/.github/workflows/engines-build.yml
+++ b/.github/workflows/engines-build.yml
@@ -1,0 +1,57 @@
+name: Build Engines Base Image
+
+# This workflow builds pre-compiled llama.cpp binaries (LLM + Audio).
+# Only run manually or when engines/ changes — this is the slow build.
+# The main docker-build.yml uses the output image and is fast (~5-10 min).
+
+on:
+  push:
+    paths:
+      - 'engines/**'
+    branches: [main]
+  workflow_dispatch:
+    inputs:
+      cuda_architectures:
+        description: 'CUDA architectures (semicolon-separated)'
+        default: '80;89;90;120'
+        required: false
+      tag:
+        description: 'Image tag override (default: latest)'
+        default: 'latest'
+        required: false
+
+jobs:
+  build-engines:
+    runs-on: DO
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Set environment variables
+        run: |
+          echo "DOCKERHUB_REPO=${{ vars.DOCKERHUB_REPO || secrets.DOCKERHUB_USERNAME }}" >> $GITHUB_ENV
+          echo "TAG=${{ github.event.inputs.tag || 'latest' }}" >> $GITHUB_ENV
+          echo "CUDA_ARCHS=${{ github.event.inputs.cuda_architectures || '80;89;90;120' }}" >> $GITHUB_ENV
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Build and push engines image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: engines/Dockerfile
+          push: true
+          build-args: |
+            CUDA_ARCHITECTURES=${{ env.CUDA_ARCHS }}
+          tags: |
+            ${{ env.DOCKERHUB_REPO }}/openclaw2go-engines:${{ env.TAG }}
+          platforms: linux/amd64
+          cache-from: type=registry,ref=${{ env.DOCKERHUB_REPO }}/openclaw2go-engines:buildcache
+          cache-to: type=registry,ref=${{ env.DOCKERHUB_REPO }}/openclaw2go-engines:buildcache,mode=max

--- a/engines/Dockerfile
+++ b/engines/Dockerfile
@@ -1,0 +1,84 @@
+# engines/Dockerfile - Pre-built llama.cpp binaries for OpenClaw2Go
+#
+# Builds LLM and Audio engines separately (incompatible .so files).
+# Produces a minimal image with just binaries + libs at /opt/engines/.
+# The main Dockerfile.unified COPYs from this image — no compilation needed.
+#
+# Build:
+#   docker build -f engines/Dockerfile -t runpod/openclaw2go-engines:latest .
+#
+# Only rebuild when:
+#   - llama.cpp has a new version you need
+#   - Adding a new CUDA architecture (new GPU support)
+#   - The audio PR branch (liquid-audio) updates
+
+ARG CUDA_VERSION=12.8
+ARG UBUNTU_VERSION=24.04
+ARG CUDA_ARCHITECTURES="80;89;90;120"
+
+# ============================================================
+# Stage 1: Build llama.cpp LLM server (main branch)
+# ============================================================
+FROM nvcr.io/nvidia/cuda-dl-base:25.03-cuda${CUDA_VERSION}-devel-ubuntu${UBUNTU_VERSION} AS llamacpp-llm
+
+ARG CUDA_ARCHITECTURES
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    build-essential cmake git \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /build
+RUN git clone --depth 1 https://github.com/ggml-org/llama.cpp.git && \
+    cd llama.cpp && \
+    cmake -B build \
+        -DGGML_CUDA=ON \
+        -DGGML_NATIVE=OFF \
+        -DCMAKE_CUDA_ARCHITECTURES="${CUDA_ARCHITECTURES}" \
+        -DCMAKE_BUILD_TYPE=Release \
+        -DCMAKE_EXE_LINKER_FLAGS=-Wl,--allow-shlib-undefined && \
+    cmake --build build --config Release -j$(nproc)
+
+# ============================================================
+# Stage 2: Build llama.cpp Audio server (PR #18641 - liquid-audio)
+# ============================================================
+FROM nvcr.io/nvidia/cuda-dl-base:25.03-cuda${CUDA_VERSION}-devel-ubuntu${UBUNTU_VERSION} AS llamacpp-audio
+
+ARG CUDA_ARCHITECTURES
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    build-essential cmake git \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /build
+RUN git clone https://github.com/ggml-org/llama.cpp.git && \
+    cd llama.cpp && \
+    git fetch origin pull/18641/head:liquid-audio && \
+    git checkout liquid-audio && \
+    cmake -B build \
+        -DGGML_CUDA=ON \
+        -DGGML_NATIVE=OFF \
+        -DCMAKE_CUDA_ARCHITECTURES="${CUDA_ARCHITECTURES}" \
+        -DCMAKE_BUILD_TYPE=Release \
+        -DCMAKE_CUDA_COMPILER=/usr/local/cuda/bin/nvcc \
+        -DCMAKE_EXE_LINKER_FLAGS=-Wl,--allow-shlib-undefined && \
+    cmake --build build --target llama-liquid-audio-cli llama-liquid-audio-server -j$(nproc)
+
+# ============================================================
+# Stage 3: Minimal output image with just binaries + libs
+# ============================================================
+FROM ubuntu:24.04
+
+# LLM engine
+COPY --from=llamacpp-llm /build/llama.cpp/build/bin/llama-server /opt/engines/llamacpp-llm/bin/
+COPY --from=llamacpp-llm /build/llama.cpp/build/bin/llama-cli /opt/engines/llamacpp-llm/bin/
+COPY --from=llamacpp-llm /build/llama.cpp/build/bin/*.so* /opt/engines/llamacpp-llm/lib/
+
+# Audio engine
+COPY --from=llamacpp-audio /build/llama.cpp/build/bin/llama-liquid-audio-cli /opt/engines/llamacpp-audio/bin/
+COPY --from=llamacpp-audio /build/llama.cpp/build/bin/llama-liquid-audio-server /opt/engines/llamacpp-audio/bin/
+COPY --from=llamacpp-audio /build/llama.cpp/build/bin/*.so* /opt/engines/llamacpp-audio/lib/
+
+RUN chmod +x /opt/engines/llamacpp-llm/bin/* /opt/engines/llamacpp-audio/bin/*
+
+# Metadata
+LABEL org.opencontainers.image.description="Pre-built llama.cpp engines for OpenClaw2Go"


### PR DESCRIPTION
## Summary
- Adds `engines-build.yml` workflow for building pre-compiled llama.cpp binaries (LLM + Audio)
- Adds `engines/Dockerfile` with multi-stage build for LLM and Audio engines
- CUDA architectures: sm_80 (A100), sm_89 (4090/L40), sm_90 (H100), sm_120 (5090)

This is a prerequisite for triggering engine builds via `workflow_dispatch`. The workflow only runs on `engines/` changes to main or manual trigger.

## Why
GitHub requires `workflow_dispatch` workflows to exist on the default branch before they can be triggered from any branch. This small PR unblocks engine builds.