### PR TITLE
fix(site): remove unused PARAM_KEYS constant breaking prod build

### DIFF
--- a/site/src/lib/url-state.ts
+++ b/site/src/lib/url-state.ts
@@ -9,8 +9,6 @@ export interface UrlState {
   vram: number | null
 }
 
-const PARAM_KEYS = ['os', 'llm', 'image', 'audio', 'gpu', 'vram'] as const
-
 const VALID_OS: Set<string> = new Set(['linux', 'windows', 'mac'])
 
 /** Parse current URL search params into typed state */


### PR DESCRIPTION
## Summary
- Removes unused `PARAM_KEYS` constant in `site/src/lib/url-state.ts` that caused `TS6133` error during production build
- Fixes the failing site workflow on main

## Test plan
- [x] Verified `npm run build:prod` passes locally