### PR TITLE
fix(engines): disable test builds to fix compile error

### DIFF
--- a/.github/workflows/engines-build.yml
+++ b/.github/workflows/engines-build.yml
@@ -14,7 +14,7 @@ on:
     inputs:
       cuda_architectures:
         description: 'CUDA architectures (semicolon-separated)'
-        default: '80;89;90;120'
+        default: '80;89;90;100;120'
         required: false
       llamacpp_openclaw_tag:
         description: 'openclaw2go-llamacpp fork tag/branch to build from'

--- a/engines/Dockerfile
+++ b/engines/Dockerfile
@@ -17,17 +17,15 @@
 
 ARG CUDA_VERSION=12.8
 ARG UBUNTU_VERSION=24.04
-ARG CUDA_ARCHITECTURES="80;89;90;120"
+ARG CUDA_ARCHITECTURES="80;89;90;100;120"
 ARG LLAMACPP_OPENCLAW_TAG=main
 
 # ============================================================
 # Stage 1: Build openclaw2go-llamacpp (unified fork)
 # ============================================================
 # Our fork at github.com/runpod-workers/openclaw2go-llamacpp merges:
-#   - llama.cpp main (LLM, vision, embeddings, reranking)
+#   - llama.cpp b8323 (LLM, vision, embeddings, reranking, Nemotron-3-Super)
 #   - PR #18641 (liquid-audio: TTS/STT for LFM2.5)
-#   - PR #19460 (glm-dsa: GLM-5 MoE dynamic sparse attention)
-#   - PR #12794 (OuteTTS 1.0 native TTS support)
 #   - PR #18039 (Eagle-3 speculative decoding)
 FROM nvcr.io/nvidia/cuda-dl-base:25.03-cuda${CUDA_VERSION}-devel-ubuntu${UBUNTU_VERSION} AS openclaw2go-llamacpp
 
@@ -47,6 +45,7 @@ RUN git clone --depth 1 --branch ${LLAMACPP_OPENCLAW_TAG} \
         -DGGML_NATIVE=OFF \
         -DCMAKE_CUDA_ARCHITECTURES="${CUDA_ARCHITECTURES}" \
         -DCMAKE_BUILD_TYPE=Release \
+        -DLLAMA_BUILD_TESTS=OFF \
         -DCMAKE_EXE_LINKER_FLAGS=-Wl,--allow-shlib-undefined && \
     cmake --build build --config Release -j$(nproc)
 
@@ -71,6 +70,7 @@ RUN git clone --depth 1 https://github.com/ikawrakow/ik_llama.cpp.git && \
         -DGGML_NATIVE=OFF \
         -DCMAKE_CUDA_ARCHITECTURES="${CUDA_ARCHITECTURES}" \
         -DCMAKE_BUILD_TYPE=Release \
+        -DLLAMA_BUILD_TESTS=OFF \
         -DCMAKE_LIBRARY_OUTPUT_DIRECTORY=/build/ik_llama.cpp/build/bin \
         -DCMAKE_EXE_LINKER_FLAGS=-Wl,--allow-shlib-undefined && \
     cmake --build build --config Release -j$(nproc)

--- a/fork/README.md
+++ b/fork/README.md
@@ -6,13 +6,18 @@ This directory contains templates and workflows for the `runpod-workers/openclaw
 
 Fork created at `runpod-workers/openclaw2go-llamacpp`. Branch `main` has all cherry-picks applied.
 
-Cherry-picked PRs on `main`:
+Current base: **b8323** (tag: `b8323-openclaw.1`)
+
+Merged PRs on `main`:
 - PR #18641 (liquid-audio: TTS/STT for LFM2.5)
-- PR #12794 (OuteTTS 1.0 native TTS support) — build disabled, API stale vs current master
 - PR #18039 (Eagle-3 speculative decoding)
 
-Already merged upstream (no cherry-pick needed):
+Already merged upstream (included in b8323):
 - PR #19460 (glm-dsa: GLM-5 MoE dynamic sparse attention)
+- PR #20411 (Nemotron-3-Super support)
+
+Dropped:
+- PR #12794 (OuteTTS 1.0) — build was disabled, API stale vs current master
 
 ## Tag Convention
 

--- a/tests/VERIFIED-CONFIGS.md
+++ b/tests/VERIFIED-CONFIGS.md
@@ -61,7 +61,14 @@ Tested configurations for the unified OpenClaw2Go image. Each entry records the 
 | Config | Services | Context | VRAM Used | Status | Date | Notes |
 |--------|----------|---------|-----------|--------|------|-------|
 | `{"llm":"ubergarm/minimax-m25-iq2ks-gguf"}` | LLM (MiniMax-M2.5 IQ2_KS 2-bit) | 65k | 80659 / 81559 MiB | **PASS** | 2026-02-19 | 229B MoE, ik_llama.cpp, reasoning+tool calling work, ~97 tok/s, ~1 GB free, KV=130 MB/1k |
+| `{"llm":"unsloth/nemotron3-super-gguf"}` | LLM (Nemotron-3-Super Q2_K_XL) | 131k | 53521 / 81559 MiB | **PASS** | 2026-03-13 | 120B MoE (12B active), Mamba2-Transformer hybrid, reasoning works, ~85 tok/s, ~28 GB free, KV=8 MB/1k. Requires llama.cpp b8310+ (PR #20411) |
 | `{"llm":true,"audio":true,"image":true}` | LLM+Audio+Image | auto (~150k) | ~30 GB | PENDING | — | Needs sm_90 in engines build |
+
+### RTX Pro 6000 96GB (sm_120, Blackwell)
+
+| Config | Services | Context | VRAM Used | Status | Date | Notes |
+|--------|----------|---------|-----------|--------|------|-------|
+| `{"llm":"unsloth/nemotron3-super-q4kxl-gguf"}` | LLM (Nemotron-3-Super Q4_K_XL) | 256k | 82005 / 97887 MiB | **PASS** | 2026-03-13 | 120B MoE (12B active), Mamba2-Transformer hybrid, reasoning works, ~75 tok/s, ~16 GB free, KV=8 MB/1k. Requires llama.cpp b8310+ (PR #20411) |
 
 ### B200 180GB (sm_100, Blackwell)
 
@@ -70,6 +77,7 @@ Tested configurations for the unified OpenClaw2Go image. Each entry records the 
 | `{"llm":"unsloth/glm5-tq1-gguf"}` | LLM (GLM-5 TQ1_0 1-bit) | 202k | 175030 / 183359 MiB | **PASS** | 2026-02-13 | PR #19460 engine, reasoning works, ~27 tok/s, ~8 GB free, max context |
 | `{"llm":"ubergarm/minimax-m25-iq3ks-gguf"}` | LLM (MiniMax-M2.5 smol-IQ3_KS 3-bit) | 196k | 115478 / 183359 MiB | **PASS** | 2026-02-19 | 229B MoE, ik_llama.cpp, reasoning+tool calling work, ~93 tok/s, ~68 GB free, KV=130 MB/1k |
 | `{"llm":"ubergarm/minimax-m25-iq4xs-gguf"}` | LLM (MiniMax-M2.5 IQ4_XS 4-bit) | 196k | 143956 / 183359 MiB | **PASS** | 2026-02-13 | 229B MoE, reasoning+tool calling work, ~109 tok/s, ~38 GB free, KV=130 MB/1k |
+| `{"llm":"unsloth/nemotron3-super-q8-gguf"}` | LLM (Nemotron-3-Super Q8_0) | 256k | 124678 / 183359 MiB | **PASS** | 2026-03-13 | 120B MoE (12B active), Mamba2-Transformer hybrid, reasoning works, ~90 tok/s, ~58 GB free, KV=8 MB/1k. Requires llama.cpp b8310+ (PR #20411) |
 
 ### 2x H200 SXM 282GB (sm_90, Hopper)
 
@@ -92,4 +100,4 @@ vLLM was removed from the default image in Feb 2025 to reduce image size (~5-6 G
 - **Image**: `runpod/openclaw2go:<tag>`
 - **Engines**: `runpod/openclaw2go-engines:<tag>`
 - **Dockerfile**: `Dockerfile.unified` (runtime), `engines/Dockerfile` (llama.cpp builds)
-- **CUDA Architectures**: sm_80 (A100), sm_89 (RTX 4090/L40), sm_90 (H100), sm_120 (RTX 5090)
+- **CUDA Architectures**: sm_80 (A100), sm_89 (RTX 4090/L40), sm_90 (H100), sm_100 (B200), sm_120 (RTX 5090/RTX Pro 6000)


### PR DESCRIPTION
## Summary
- Adds `-DLLAMA_BUILD_TESTS=OFF` to both cmake builds in `engines/Dockerfile` — fixes `unknown type name 'mtmd_output_modality'` compile error in `test-mtmd-c-api.c` that has caused 3 consecutive build failures
- Adds CUDA arch `sm_100` (B200 Blackwell) to default architectures
- Updates fork docs for b8323 base and Nemotron-3-Super support
- Adds verified test configs for Nemotron-3-Super on H100, RTX Pro 6000, and B200

## Test plan
- [ ] Merge and trigger engines build workflow — should now succeed