### PR TITLE
fix: add version metadata to a2go skill

### DIFF
--- a/skills/a2go/SKILL.md
+++ b/skills/a2go/SKILL.md
@@ -3,6 +3,7 @@ name: a2go
 description: Use open weight models (LLM, image, audio) with open source agents on Mac, Linux, and Windows.
 metadata:
   author: runpod
+  version: "0.15.1"
 ---
 
 # a2go


### PR DESCRIPTION
## Summary
- Add `version: "0.15.1"` to SKILL.md frontmatter metadata
- May trigger re-indexing on skills.sh to refresh stale security audit results (see vercel-labs/skills#707, #815, #483)

## Context
Security audits on skills.sh have been stuck at cached results from Apr 9 01:44 PM despite merging fixes that eliminated Snyk E005 (critical) and reduced W012. A frontmatter change was the workaround that resolved a similar issue in vercel-labs/skills#483.