### PR TITLE
feat: rename LLAMACPP_API_KEY to A2GO_API_KEY

### DIFF
--- a/.changeset/rename-api-key.md
+++ b/.changeset/rename-api-key.md
@@ -1,0 +1,5 @@
+---
+"a2go": minor
+---
+
+Rename LLAMACPP_API_KEY to A2GO_API_KEY for engine-agnostic API authentication

--- a/Dockerfile.unified
+++ b/Dockerfile.unified
@@ -109,7 +109,7 @@ ENV PATH="/root/.local/bin:${PATH}"
 WORKDIR /
 
 # ── Environment defaults ──────────────────────────────────
-ENV LLAMACPP_API_KEY="changeme" \
+ENV A2GO_API_KEY="changeme" \
     A2GO_AUTH_TOKEN="changeme" \
     A2GO_STATE_DIR="" \
     A2GO_WORKSPACE="" \

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ The site generates this — or run it directly:
 docker run --gpus all \
   -e A2GO_CONFIG='{"llm":"unsloth/GLM-4.7-Flash-GGUF","audio":"LiquidAI/LFM2.5-Audio-1.5B-GGUF"}' \
   -e A2GO_AUTH_TOKEN=changeme \
-  -e LLAMACPP_API_KEY=changeme \
+  -e A2GO_API_KEY=changeme \
   -p 8000:8000 -p 8080:8080 -p 18789:18789 \
   -v a2go-models:/workspace \
   runpod/a2go:latest
@@ -50,7 +50,7 @@ Models download on first start and persist on the volume.
 |----------|-------------|---------|
 | `A2GO_CONFIG` | JSON config — models to load | `{}` (auto-detect) |
 | `A2GO_AUTH_TOKEN` | Web UI + API auth token | `changeme` |
-| `LLAMACPP_API_KEY` | LLM API key (OpenAI-compatible endpoint) | `changeme` |
+| `A2GO_API_KEY` | LLM API key (OpenAI-compatible endpoint) | `changeme` |
 | `TELEGRAM_BOT_TOKEN` | Enable Telegram bot integration | — |
 | `GITHUB_TOKEN` | GitHub auth for Claude Code | — |
 

--- a/a2go/cmd/run.go
+++ b/a2go/cmd/run.go
@@ -200,7 +200,7 @@ func execRunDocker(cfg *config.Config) error {
 		Env: map[string]string{
 			"A2GO_CONFIG":     configJSON,
 			"A2GO_AUTH_TOKEN":  cfg.GetAuthToken(),
-			"LLAMACPP_API_KEY": cfg.GetAuthToken(),
+			"A2GO_API_KEY": cfg.GetAuthToken(),
 		},
 		Ports: []string{
 			"8000:8000",

--- a/scripts/entrypoint-unified.sh
+++ b/scripts/entrypoint-unified.sh
@@ -142,8 +142,7 @@ echo "$RESOLVED_JSON" > /tmp/oc_resolved.json
 # ============================================================
 # Environment defaults
 # ============================================================
-# Support both LLAMACPP_API_KEY (new) and LLAMA_API_KEY (deprecated)
-LLAMACPP_API_KEY="${LLAMACPP_API_KEY:-${LLAMA_API_KEY:-changeme}}"
+A2GO_API_KEY="${A2GO_API_KEY:-changeme}"
 
 # ── Canonical A2GO_* env vars with backward-compat fallback to OPENCLAW_* ──
 # Users can set either; A2GO_* takes precedence. Old names supported forever.
@@ -155,8 +154,8 @@ A2GO_WEB_PROXY_PORT="${A2GO_WEB_PROXY_PORT:-8080}"
 # Hermes blocklists placeholder secrets ("changeme", "dummy", etc.)
 # When using Hermes with a placeholder key, substitute a non-blocked value
 # that still matches what the LLM server expects.
-if [ "$AGENT" = "hermes" ] && [ "$LLAMACPP_API_KEY" = "changeme" ]; then
-    LLAMACPP_API_KEY="a2go-local-changeme"
+if [ "$AGENT" = "hermes" ] && [ "$A2GO_API_KEY" = "changeme" ]; then
+    A2GO_API_KEY="a2go-local-changeme"
     A2GO_AUTH_TOKEN="${A2GO_AUTH_TOKEN:-a2go-local-changeme}"
     echo "Note: Hermes requires non-placeholder API keys. Using 'a2go-local-changeme' instead of 'changeme'."
 fi
@@ -358,7 +357,7 @@ print(' '.join(f'{k}={v}' for k,v in env_vars.items()))
                     -ctk q8_0
                     -ctv q8_0
                     --no-mmap
-                    --api-key "$LLAMACPP_API_KEY"
+                    --api-key "$A2GO_API_KEY"
                 )
 
                 # Add -ngl unless "auto" (let --fit determine GPU layers)
@@ -452,7 +451,7 @@ json.dump(plugins, sys.stdout)
                 --host 0.0.0.0
                 --port "$port"
                 -ngl 99
-                --api-key "$LLAMACPP_API_KEY"
+                --api-key "$A2GO_API_KEY"
             )
 
             if [ -n "$MMPROJ_FILE" ]; then
@@ -483,7 +482,7 @@ json.dump(plugins, sys.stdout)
                 --port "$port"
                 -ngl 99
                 --embedding
-                --api-key "$LLAMACPP_API_KEY"
+                --api-key "$A2GO_API_KEY"
             )
 
             if [ -n "$EXTRA_START_ARGS" ]; then
@@ -513,7 +512,7 @@ json.dump(plugins, sys.stdout)
                 --port "$port"
                 -ngl 99
                 --reranking
-                --api-key "$LLAMACPP_API_KEY"
+                --api-key "$A2GO_API_KEY"
             )
 
             env LD_LIBRARY_PATH="$ENGINE_LIB_PATH" \
@@ -664,7 +663,7 @@ elif [ -d "/workspace/.config/gh" ] && [ -f "/workspace/.config/gh/hosts.yml" ];
 fi
 
 # Setup Claude Code environment (OpenAI-compatible)
-export OPENAI_API_KEY="$LLAMACPP_API_KEY"
+export OPENAI_API_KEY="$A2GO_API_KEY"
 export OPENAI_BASE_URL="http://localhost:${LLM_PORT}/v1"
 
 GATEWAY_PID=""
@@ -708,7 +707,7 @@ case "$AGENT" in
     "providers": {
       "$LLM_PROVIDER_NAME": {
         "baseUrl": "http://localhost:${LLM_PORT}/v1",
-        "apiKey": "$LLAMACPP_API_KEY",
+        "apiKey": "$A2GO_API_KEY",
         "api": "openai-completions",
         "models": [{
           "id": "$LLM_MODEL_NAME",
@@ -794,7 +793,7 @@ model:
   provider: custom
   default: $LLM_MODEL_NAME
   base_url: http://localhost:${LLM_PORT}/v1
-  api_key: $LLAMACPP_API_KEY
+  api_key: $A2GO_API_KEY
   context_length: $LLM_CONTEXT
 memory:
   memory_enabled: true
@@ -806,7 +805,7 @@ EOF
 
         # Generate .env for Hermes
         cat > "$HERMES_DIR/.env" << EOF
-OPENAI_API_KEY=$LLAMACPP_API_KEY
+OPENAI_API_KEY=$A2GO_API_KEY
 OPENAI_BASE_URL=http://localhost:${LLM_PORT}/v1
 EOF
 
@@ -830,7 +829,7 @@ EOF
         # Start Hermes gateway (API server on port 8642, foreground mode, backgrounded by us)
         echo ""
         echo "Starting Hermes gateway..."
-        OPENAI_API_KEY="$LLAMACPP_API_KEY" \
+        OPENAI_API_KEY="$A2GO_API_KEY" \
         OPENAI_BASE_URL="http://localhost:${LLM_PORT}/v1" \
         API_SERVER_ENABLED=true \
         API_SERVER_PORT=8642 \

--- a/site/src/components/DeployOutput.tsx
+++ b/site/src/components/DeployOutput.tsx
@@ -208,7 +208,7 @@ function buildCloudConfig(
     envVars: [
       { key: 'A2GO_CONFIG', value: configJSON },
       { key: 'A2GO_AUTH_TOKEN', value: 'changeme' },
-      { key: 'LLAMACPP_API_KEY', value: 'changeme' },
+      { key: 'A2GO_API_KEY', value: 'changeme' },
     ],
     ports: [
       agentId === 'hermes'

--- a/templates/runpod/readme.md
+++ b/templates/runpod/readme.md
@@ -1,14 +1,34 @@
-# a2go
-
 Use open weight models (LLM, image, audio) with open source agents on GPU pods. a2go bundles local LLM inference, image generation, and audio services into a single Docker image — everything agents like [Hermes](https://github.com/hermes-agent/hermes) and [OpenClaw](https://openclaw.ai) need to operate autonomously.
 
 ## Quick Start
 
-1. Go to [a2go.run](https://a2go.run) and pick models for your GPU
-2. Copy the generated `A2GO_CONFIG` JSON
-3. Paste it into the `A2GO_CONFIG` environment variable when deploying this template
-4. Set `A2GO_AUTH_TOKEN` and `LLAMACPP_API_KEY` to secure your pod
-5. Deploy - the pod auto-downloads models and starts all services
+### 1. Pick your models
+
+Go to [a2go.run](https://a2go.run), select your GPU, and choose the models you want to run. The site shows what fits your VRAM and generates the configuration for you.
+
+### 2. Set the environment variables
+
+When deploying this template, fill in these three environment variables:
+
+| Variable | What to put in | Why it's needed |
+|----------|---------------|-----------------|
+| `A2GO_CONFIG` | Paste the JSON from [a2go.run](https://a2go.run) — it tells the pod which models to download and run. Leave empty to auto-detect the best model for your GPU. | Configures which LLM, image, and audio models to load |
+| `A2GO_AUTH_TOKEN` | A secure password you choose (e.g. `my-secret-token-123`). **Do not leave as `changeme`.** | Authenticates the web UI and agent gateway (OpenClaw / Hermes) — anyone with this token can access your pod |
+| `A2GO_API_KEY` | A secure API key you choose (e.g. `sk-my-secret-key`). **Do not leave as `changeme`.** | Secures the LLM server. Used both by the agent internally (to talk to the local LLM) and for external API access (`/v1/chat/completions`) |
+
+Use [Runpod Secrets](https://docs.runpod.io/pods/templates/secrets) for `A2GO_AUTH_TOKEN` and `A2GO_API_KEY` to keep them out of your template config.
+
+### 3. Deploy
+
+Hit deploy. The pod will automatically download your selected models and start all services. First boot takes a few minutes depending on model size — subsequent starts use the cached models on your volume.
+
+### 4. Access
+
+Once the pod is running, open:
+
+`https://<pod-id>-18789.proxy.runpod.net/?token=<A2GO_AUTH_TOKEN>`
+
+Replace `<pod-id>` with your pod ID (shown in the Runpod dashboard) and `<A2GO_AUTH_TOKEN>` with the password you set in step 2.
 
 ## Auto-Detect Mode
 
@@ -42,8 +62,8 @@ Models are cached in `/workspace/models/` and persist across pod restarts.
 
 | Variable | Description |
 |----------|-------------|
-| `A2GO_AUTH_TOKEN` | Auth token for the gateway + API |
-| `LLAMACPP_API_KEY` | Protects the OpenAI-compatible LLM endpoint |
+| `A2GO_AUTH_TOKEN` | Authenticates the web UI and agent gateway (OpenClaw / Hermes) |
+| `A2GO_API_KEY` | Secures all a2go API endpoints (LLM, media, future services) |
 
 ### Recommended
 

--- a/templates/runpod/update.json
+++ b/templates/runpod/update.json
@@ -1,5 +1,5 @@
 {
-  "name": "agent2go",
+  "name": "a2go",
   "imageName": "runpod/a2go:latest",
   "containerDiskInGb": 20,
   "ports": "8000/http,8080/http,8642/http,18789/http,22/tcp",
@@ -13,7 +13,7 @@
       "value": ""
     },
     {
-      "key": "LLAMACPP_API_KEY",
+      "key": "A2GO_API_KEY",
       "value": ""
     },
     {


### PR DESCRIPTION
## Summary

- Renames `LLAMACPP_API_KEY` to `A2GO_API_KEY` across the entire codebase (7 files) — engine-agnostic API key that can secure any a2go service (LLM, media, future backends) instead of being tied to llama.cpp
- Removes the deprecated `LLAMA_API_KEY` fallback (was an old a2go-internal name, not a llama.cpp default)
- Updates `templates/runpod/update.json` name from `agent2go` to `a2go`
- Rewrites `templates/runpod/readme.md` Quick Start with clear step-by-step env var explanations (what to put in, why it's needed)
- Removes redundant `# a2go` headline from RunPod template README (already shown on the page)

**Note:** The live RunPod template (`4hgezzzadd`) has already been updated with the new env var key, name, and README via template-utils. This PR aligns the codebase so the next Docker image build picks up `A2GO_API_KEY`.

## Test plan

- [ ] Build the Docker image from this branch (`docker build -f Dockerfile.unified -t a2go:test .`)
- [ ] Deploy a pod with `A2GO_API_KEY=test-key` and verify the LLM endpoint requires that key
- [ ] Verify the agent (OpenClaw/Hermes) can still talk to the local LLM (key gets written into config)
- [ ] Check [a2go.run](https://a2go.run) cloud tab shows `A2GO_API_KEY` instead of `LLAMACPP_API_KEY`
- [ ] Verify `OPENAI_API_KEY` export inside the pod matches the `A2GO_API_KEY` value