### PR TITLE
fix: correct package name in cloud-provider-templates changeset

### DIFF
--- a/.changeset/cloud-provider-templates.md
+++ b/.changeset/cloud-provider-templates.md
@@ -1,5 +1,5 @@
 ---
-"site": patch
+"a2go": patch
 ---
 
 feat(site): add cloud provider templates to deploy section


### PR DESCRIPTION
## Summary

- The `cloud-provider-templates` changeset from #143 references `"site"` as the package name, but the workspace package is `"a2go"` — this breaks `changeset version` in the release workflow

## Test plan

- [ ] Merge and verify the release workflow passes