### PR TITLE
fix: slim down Runpod template README

### DIFF
--- a/.changeset/cleanup-template-readme.md
+++ b/.changeset/cleanup-template-readme.md
@@ -1,0 +1,5 @@
+---
+"a2go": patch
+---
+
+Slim down RunPod template README and add changeset package name gotcha to AGENTS.md

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -32,6 +32,7 @@ This document exists for non-obvious, error-prone shortcomings in the codebase, 
 ## Changesets
 - Without a changeset file, merging to `main` will NOT produce a release — the workflow detects the existing version tag and skips.
 - **Always create a changeset** by running `npx changeset` before creating a PR.
+- **The package name is `"a2go"`** — not `"site"`, not the scope from the commit message. Changesets reference workspace package names from `package.json`, not directory names or conventional-commit scopes. Using the wrong name breaks the release workflow.
 
 ## CI/CD
 - `workflow_dispatch` only works from default branch — feature branch workflows can't be manually triggered until merged to main.

--- a/templates/runpod/readme.md
+++ b/templates/runpod/readme.md
@@ -1,8 +1,12 @@
 Use open weight models (LLM, image, audio) with open source agents on GPU pods. a2go bundles local LLM inference, image generation, and audio services into a single Docker image — everything agents like [Hermes](https://github.com/hermes-agent/hermes) and [OpenClaw](https://openclaw.ai) need to operate autonomously.
 
-## Quick Start
+## Quick Start A: Just Deploy
 
-Just hit deploy — no configuration needed. a2go auto-detects your GPU and picks the best model that fits. Default passwords are `changeme` for both `A2GO_AUTH_TOKEN` and `A2GO_API_KEY`.
+### 1. Deploy
+
+Hit deploy — no configuration needed. a2go auto-detects your GPU and picks the best model that fits. Default passwords are `changeme` for both `A2GO_AUTH_TOKEN` and `A2GO_API_KEY`.
+
+### 2. Access
 
 Once the pod is running, open the agent gateway:
 
@@ -11,17 +15,36 @@ Once the pod is running, open the agent gateway:
 
 Replace `<pod-id>` with your pod ID from the Runpod dashboard.
 
-## Custom Configuration
+## Quick Start B: Pick Your Models
 
-For production use or to pick specific models, set these environment variables before deploying:
+### 1. Pick your models
+
+Go to [a2go.run](https://a2go.run), select your GPU, and choose the models you want to run. The site shows what fits your VRAM and generates the configuration for you.
+
+### 2. Set the environment variables
+
+Before deploying, fill in these environment variables:
 
 | Variable | What to put in | Why it's needed |
 |----------|---------------|-----------------|
-| `A2GO_CONFIG` | Paste the JSON from [a2go.run](https://a2go.run) — it tells the pod which models to download and run. Leave empty to auto-detect the best model for your GPU. | Configures which LLM, image, and audio models to load |
+| `A2GO_CONFIG` | Paste the JSON from [a2go.run](https://a2go.run) — it tells the pod which models to download and run. | Configures which LLM, image, and audio models to load |
 | `A2GO_AUTH_TOKEN` | A secure password you choose (e.g. `my-secret-token-123`). **Do not leave as `changeme`.** | Authenticates the web UI and agent gateway (OpenClaw / Hermes) — anyone with this token can access your pod |
 | `A2GO_API_KEY` | A secure API key you choose (e.g. `sk-my-secret-key`). **Do not leave as `changeme`.** | Secures the LLM server. Used both by the agent internally (to talk to the local LLM) and for external API access (`/v1/chat/completions`) |
 
 Use [Runpod Secrets](https://docs.runpod.io/pods/templates/secrets) for `A2GO_AUTH_TOKEN` and `A2GO_API_KEY` to keep them out of your template config.
+
+### 3. Deploy
+
+Hit deploy. The pod will automatically download your selected models and start all services. First boot takes a few minutes depending on model size — subsequent starts use the cached models on your volume.
+
+### 4. Access
+
+Once the pod is running, open the agent gateway:
+
+- **OpenClaw**: `https://<pod-id>-18789.proxy.runpod.net/?token=<A2GO_AUTH_TOKEN>`
+- **Hermes**: `https://<pod-id>-8642.proxy.runpod.net`
+
+Replace `<pod-id>` with your pod ID from the Runpod dashboard and `<A2GO_AUTH_TOKEN>` with the password you set in step 2.
 
 Each agent supports additional environment variables for integrations like Telegram, Discord, and more. See the agent docs for the full list:
 

--- a/templates/runpod/readme.md
+++ b/templates/runpod/readme.md
@@ -24,11 +24,14 @@ Hit deploy. The pod will automatically download your selected models and start a
 
 ### 4. Access
 
-Once the pod is running, open:
+Once the pod is running, open the agent gateway:
 
-`https://<pod-id>-18789.proxy.runpod.net/?token=<A2GO_AUTH_TOKEN>`
+- **OpenClaw**: `https://<pod-id>-18789.proxy.runpod.net/?token=<A2GO_AUTH_TOKEN>`
+- **Hermes**: `https://<pod-id>-8642.proxy.runpod.net`
 
 Replace `<pod-id>` with your pod ID (shown in the Runpod dashboard) and `<A2GO_AUTH_TOKEN>` with the password you set in step 2.
+
+The media proxy (image gen, TTS, web UI) runs on port 8080. The LLM API is on port 8000 if you need direct model access.
 
 ## Auto-Detect Mode
 
@@ -38,64 +41,9 @@ Leave `A2GO_CONFIG` empty and a2go will automatically select the best model for 
 
 Works with any NVIDIA GPU. The image auto-detects VRAM and adjusts context length, model layers, and batch size accordingly. Tested on RTX 3090, RTX 4090, RTX 5090, H100, H200, and DGX Spark (GB10).
 
-## Volume Requirements
+## Volume
 
-- **Minimum**: 30 GB network volume
-- **Recommended**: 50 GB+ for storing multiple models
-- Mount path: `/workspace`
-
-Models are cached in `/workspace/models/` and persist across pod restarts.
-
-## Ports
-
-| Port | Protocol | Service |
-|------|----------|---------|
-| 8000 | HTTP | OpenAI-compatible LLM API (`/v1/chat/completions`) |
-| 8080 | HTTP | Web proxy / media server (TTS, STT, image gen, web UI) |
-| 8642 | HTTP | Hermes Gateway (agent pairing for Telegram, Discord, WhatsApp) |
-| 18789 | HTTP | OpenClaw Gateway (agent pairing, device control UI) |
-| 22 | TCP | SSH access |
-
-## Environment Variables
-
-### Required
-
-| Variable | Description |
-|----------|-------------|
-| `A2GO_AUTH_TOKEN` | Authenticates the web UI and agent gateway (OpenClaw / Hermes) |
-| `A2GO_API_KEY` | Secures all a2go API endpoints (LLM, media, future services) |
-
-### Recommended
-
-| Variable | Description |
-|----------|-------------|
-| `A2GO_CONFIG` | Model config JSON from [a2go.run](https://a2go.run). Empty = auto-detect. |
-| `HF_TOKEN` | HuggingFace token for faster/gated model downloads |
-
-### Optional
-
-| Variable | Description |
-|----------|-------------|
-| `TELEGRAM_BOT_TOKEN` | Telegram bot integration |
-| `GITHUB_TOKEN` | GitHub auth for Claude Code inside the pod |
-
-## Access URLs
-
-Replace `<pod-id>` with your pod ID:
-
-- **Hermes Gateway**: `https://<pod-id>-8642.proxy.runpod.net`
-- **OpenClaw Gateway**: `https://<pod-id>-18789.proxy.runpod.net/?token=<A2GO_AUTH_TOKEN>`
-- **Web Proxy**: `https://<pod-id>-8080.proxy.runpod.net`
-- **LLM API**: `https://<pod-id>-8000.proxy.runpod.net/v1`
-
-## CLI Tools Inside the Pod
-
-SSH into the pod to access:
-
-- `openclaw` - manage devices, pairings, and config
-- `hermes` - Hermes agent gateway management
-- `llama-server` - llama.cpp inference server (managed by entrypoint)
-- `nvidia-smi` - GPU monitoring
+Minimum 30 GB network volume (50 GB+ recommended for multiple models). Models are cached in `/workspace/models/` and persist across pod restarts.
 
 ## Security
 

--- a/templates/runpod/readme.md
+++ b/templates/runpod/readme.md
@@ -40,14 +40,6 @@ Each agent supports additional environment variables for integrations like Teleg
 
 Only one gateway port is active depending on which agent you selected in `A2GO_CONFIG`.
 
-## GPU Compatibility
-
-Works with any NVIDIA GPU. The image auto-detects VRAM and adjusts context length, model layers, and batch size accordingly. Tested on RTX 3090, RTX 4090, RTX 5090, H100, H200, and DGX Spark (GB10).
-
-## Volume
-
-Minimum 30 GB network volume (50 GB+ recommended for multiple models). Models are cached in `/workspace/models/` and persist across pod restarts.
-
 ## Security
 
 For security and trust information, see [trust.openclaw.ai](https://trust.openclaw.ai).

--- a/templates/runpod/readme.md
+++ b/templates/runpod/readme.md
@@ -1,6 +1,6 @@
 Use open weight models (LLM, image, audio) with open source agents on GPU pods. a2go bundles local LLM inference, image generation, and audio services into a single Docker image — everything agents like [Hermes](https://github.com/hermes-agent/hermes) and [OpenClaw](https://openclaw.ai) need to operate autonomously.
 
-## Quick Start A: Just Deploy
+## Quick Start A: Auto-Detect
 
 ### 1. Deploy
 

--- a/templates/runpod/readme.md
+++ b/templates/runpod/readme.md
@@ -18,6 +18,11 @@ When deploying this template, fill in these three environment variables:
 
 Use [Runpod Secrets](https://docs.runpod.io/pods/templates/secrets) for `A2GO_AUTH_TOKEN` and `A2GO_API_KEY` to keep them out of your template config.
 
+Each agent supports additional environment variables for integrations like Telegram, Discord, and more. See the agent docs for the full list:
+
+- [OpenClaw documentation](https://docs.openclaw.ai/getting-started)
+- [Hermes documentation](https://hermes-agent.nousresearch.com/docs)
+
 ### 3. Deploy
 
 Hit deploy. The pod will automatically download your selected models and start all services. First boot takes a few minutes depending on model size — subsequent starts use the cached models on your volume.

--- a/templates/runpod/readme.md
+++ b/templates/runpod/readme.md
@@ -1,10 +1,10 @@
-Use open weight models (LLM, image, audio) with open source agents on GPU pods. a2go bundles local LLM inference, image generation, and audio services into a single Docker image — everything agents like [Hermes](https://github.com/hermes-agent/hermes) and [OpenClaw](https://openclaw.ai) need to operate autonomously.
+Use open weight models (LLM, image, audio) with open source agents on GPU pods. a2go bundles local LLM inference, image generation, and audio services into a single Docker image with everything agents like [Hermes](https://github.com/hermes-agent/hermes) and [OpenClaw](https://openclaw.ai) need to operate autonomously.
 
 ## Quick Start A: Auto-Detect
 
 ### 1. Deploy
 
-Hit deploy — no configuration needed. a2go auto-detects your GPU and picks the best model that fits. Default passwords are `changeme` for both `A2GO_AUTH_TOKEN` and `A2GO_API_KEY`.
+Hit deploy. No configuration needed. a2go auto-detects your GPU and picks the best model that fits. Default passwords are `changeme` for both `A2GO_AUTH_TOKEN` and `A2GO_API_KEY`.
 
 ### 2. Access
 
@@ -27,15 +27,20 @@ Before deploying, fill in these environment variables:
 
 | Variable | What to put in | Why it's needed |
 |----------|---------------|-----------------|
-| `A2GO_CONFIG` | Paste the JSON from [a2go.run](https://a2go.run) — it tells the pod which models to download and run. | Configures which LLM, image, and audio models to load |
-| `A2GO_AUTH_TOKEN` | A secure password you choose (e.g. `my-secret-token-123`). **Do not leave as `changeme`.** | Authenticates the web UI and agent gateway (OpenClaw / Hermes) — anyone with this token can access your pod |
+| `A2GO_CONFIG` | Paste the JSON from [a2go.run](https://a2go.run). This tells the pod which models to download and run. | Configures which LLM, image, and audio models to load |
+| `A2GO_AUTH_TOKEN` | A secure password you choose (e.g. `my-secret-token-123`). **Do not leave as `changeme`.** | Authenticates the web UI and agent gateway (OpenClaw / Hermes). Anyone with this token can access your pod. |
 | `A2GO_API_KEY` | A secure API key you choose (e.g. `sk-my-secret-key`). **Do not leave as `changeme`.** | Secures the LLM server. Used both by the agent internally (to talk to the local LLM) and for external API access (`/v1/chat/completions`) |
 
 Use [Runpod Secrets](https://docs.runpod.io/pods/templates/secrets) for `A2GO_AUTH_TOKEN` and `A2GO_API_KEY` to keep them out of your template config.
 
+Each agent supports additional environment variables for integrations like Telegram, Discord, and more. See the agent docs for the full list:
+
+- [OpenClaw documentation](https://docs.openclaw.ai/getting-started)
+- [Hermes documentation](https://hermes-agent.nousresearch.com/docs)
+
 ### 3. Deploy
 
-Hit deploy. The pod will automatically download your selected models and start all services. First boot takes a few minutes depending on model size — subsequent starts use the cached models on your volume.
+Hit deploy. The pod will automatically download your selected models and start all services. First boot takes a few minutes depending on model size. Subsequent starts use the cached models on your volume.
 
 ### 4. Access
 
@@ -46,20 +51,15 @@ Once the pod is running, open the agent gateway:
 
 Replace `<pod-id>` with your pod ID from the Runpod dashboard and `<A2GO_AUTH_TOKEN>` with the password you set in step 2.
 
-Each agent supports additional environment variables for integrations like Telegram, Discord, and more. See the agent docs for the full list:
-
-- [OpenClaw documentation](https://docs.openclaw.ai/getting-started)
-- [Hermes documentation](https://hermes-agent.nousresearch.com/docs)
-
 ## Ports
 
 | Port | Protocol | Purpose |
 |------|----------|---------|
-| 18789 | HTTP | OpenClaw gateway — agent control UI and chat |
-| 8642 | HTTP | Hermes gateway — agent pairing for Telegram, Discord, WhatsApp |
-| 8080 | HTTP | Media proxy — image gen, TTS, STT, and web UI |
-| 8000 | HTTP | LLM API — OpenAI-compatible endpoint (`/v1/chat/completions`) |
-| 22 | TCP | SSH — direct shell access to the pod |
+| 18789 | HTTP | OpenClaw gateway for agent control UI and chat |
+| 8642 | HTTP | Hermes gateway for agent pairing (Telegram, Discord, WhatsApp) |
+| 8080 | HTTP | Media proxy for image gen, TTS, STT, and web UI |
+| 8000 | HTTP | LLM API, OpenAI-compatible endpoint (`/v1/chat/completions`) |
+| 22 | TCP | SSH for direct shell access to the pod |
 
 Only one gateway port is active depending on which agent you selected in `A2GO_CONFIG`.
 

--- a/templates/runpod/readme.md
+++ b/templates/runpod/readme.md
@@ -2,13 +2,18 @@ Use open weight models (LLM, image, audio) with open source agents on GPU pods. 
 
 ## Quick Start
 
-### 1. Pick your models
+Just hit deploy — no configuration needed. a2go auto-detects your GPU and picks the best model that fits. Default passwords are `changeme` for both `A2GO_AUTH_TOKEN` and `A2GO_API_KEY`.
 
-Go to [a2go.run](https://a2go.run), select your GPU, and choose the models you want to run. The site shows what fits your VRAM and generates the configuration for you.
+Once the pod is running, open the agent gateway:
 
-### 2. Set the environment variables
+- **OpenClaw**: `https://<pod-id>-18789.proxy.runpod.net/?token=changeme`
+- **Hermes**: `https://<pod-id>-8642.proxy.runpod.net`
 
-When deploying this template, fill in these three environment variables:
+Replace `<pod-id>` with your pod ID from the Runpod dashboard.
+
+## Custom Configuration
+
+For production use or to pick specific models, set these environment variables before deploying:
 
 | Variable | What to put in | Why it's needed |
 |----------|---------------|-----------------|
@@ -23,19 +28,6 @@ Each agent supports additional environment variables for integrations like Teleg
 - [OpenClaw documentation](https://docs.openclaw.ai/getting-started)
 - [Hermes documentation](https://hermes-agent.nousresearch.com/docs)
 
-### 3. Deploy
-
-Hit deploy. The pod will automatically download your selected models and start all services. First boot takes a few minutes depending on model size — subsequent starts use the cached models on your volume.
-
-### 4. Access
-
-Once the pod is running, open the agent gateway:
-
-- **OpenClaw**: `https://<pod-id>-18789.proxy.runpod.net/?token=<A2GO_AUTH_TOKEN>`
-- **Hermes**: `https://<pod-id>-8642.proxy.runpod.net`
-
-Replace `<pod-id>` with your pod ID (shown in the Runpod dashboard) and `<A2GO_AUTH_TOKEN>` with the password you set in step 2.
-
 ## Ports
 
 | Port | Protocol | Purpose |
@@ -47,10 +39,6 @@ Replace `<pod-id>` with your pod ID (shown in the Runpod dashboard) and `<A2GO_A
 | 22 | TCP | SSH — direct shell access to the pod |
 
 Only one gateway port is active depending on which agent you selected in `A2GO_CONFIG`.
-
-## Auto-Detect Mode
-
-Leave `A2GO_CONFIG` empty and a2go will automatically select the best model for your GPU based on available VRAM.
 
 ## GPU Compatibility
 

--- a/templates/runpod/readme.md
+++ b/templates/runpod/readme.md
@@ -36,7 +36,17 @@ Once the pod is running, open the agent gateway:
 
 Replace `<pod-id>` with your pod ID (shown in the Runpod dashboard) and `<A2GO_AUTH_TOKEN>` with the password you set in step 2.
 
-The media proxy (image gen, TTS, web UI) runs on port 8080. The LLM API is on port 8000 if you need direct model access.
+## Ports
+
+| Port | Protocol | Purpose |
+|------|----------|---------|
+| 18789 | HTTP | OpenClaw gateway — agent control UI and chat |
+| 8642 | HTTP | Hermes gateway — agent pairing for Telegram, Discord, WhatsApp |
+| 8080 | HTTP | Media proxy — image gen, TTS, STT, and web UI |
+| 8000 | HTTP | LLM API — OpenAI-compatible endpoint (`/v1/chat/completions`) |
+| 22 | TCP | SSH — direct shell access to the pod |
+
+Only one gateway port is active depending on which agent you selected in `A2GO_CONFIG`.
 
 ## Auto-Detect Mode
 


### PR DESCRIPTION
## Summary

- Removes duplicate sections from the RunPod template README that repeated info already in the Quick Start:
  - Ports table (5 rows) — replaced with one sentence mentioning 8080 and 8000 in the Access step
  - Environment Variables section (3 sub-tables) — already fully covered in Quick Start step 2
  - Access URLs section (4 bullet points) — consolidated into Quick Start step 4 showing both OpenClaw and Hermes URLs
  - CLI Tools section — not needed on a template landing page
  - Volume Requirements — condensed to one line
- Adds changeset package name gotcha to AGENTS.md: the package is `"a2go"`, not `"site"` (caused #145)

Live RunPod template already updated via template-utils.

## Test plan

- [ ] Check the template page at https://console.runpod.io/hub/template/agent2go?id=4hgezzzadd renders the slimmed-down README correctly