### PR TITLE
fix: set default values for RunPod template env vars

### DIFF
--- a/.changeset/template-env-defaults.md
+++ b/.changeset/template-env-defaults.md
@@ -1,0 +1,5 @@
+---
+"a2go": patch
+---
+
+Set default values for RunPod template environment variables

--- a/templates/runpod/update.json
+++ b/templates/runpod/update.json
@@ -6,27 +6,15 @@
   "env": [
     {
       "key": "A2GO_CONFIG",
-      "value": ""
+      "value": "{}"
     },
     {
       "key": "A2GO_AUTH_TOKEN",
-      "value": ""
+      "value": "changeme"
     },
     {
       "key": "A2GO_API_KEY",
-      "value": ""
-    },
-    {
-      "key": "HF_TOKEN",
-      "value": ""
-    },
-    {
-      "key": "TELEGRAM_BOT_TOKEN",
-      "value": ""
-    },
-    {
-      "key": "GITHUB_TOKEN",
-      "value": ""
+      "value": "changeme"
     }
   ]
 }


### PR DESCRIPTION
## Summary

- Set `A2GO_CONFIG` default to `{}` so it shows up as a visible field in the template
- Set `A2GO_AUTH_TOKEN` and `A2GO_API_KEY` defaults to `changeme` so users see prefilled values to replace
- Remove `HF_TOKEN`, `TELEGRAM_BOT_TOKEN`, and `GITHUB_TOKEN` from the template (covered by agent docs links in the README)

Live template already updated.

## Test plan

- [ ] Verify all three env vars show up prefilled when deploying from the template