### PR TITLE
fix: clear Snyk W012 from a2go skill

### DIFF
--- a/.changeset/six-meteors-search.md
+++ b/.changeset/six-meteors-search.md
@@ -1,0 +1,7 @@
+---
+"a2go": patch
+---
+
+Update the `a2go` skill examples to remove the concrete remote model reference from
+the quick start flow and point users to `a2go models` instead. This fixes the
+Snyk `W012` finding on `skills/a2go/SKILL.md`.

--- a/skills/a2go/SKILL.md
+++ b/skills/a2go/SKILL.md
@@ -17,10 +17,12 @@ Requires the `a2go` CLI. Install from GitHub releases (includes SHA256 checksums
 
 ```bash
 a2go doctor                                              # One-time setup (checks Docker, GPU, pulls image)
-a2go run --agent hermes --llm unsloth/GLM-4.7-Flash-GGUF:4bit  # Start with a model
+a2go run --agent hermes --llm <repo>:<bits>bit          # Start with a model
 a2go status                                              # Check running services
 a2go stop                                                # Stop all
 ```
+
+Pick a model value with `a2go models`; use the `repo:bits` value from the output.
 
 ## Commands
 


### PR DESCRIPTION
## Summary
- replace the concrete remote model repo in the a2go skill quick start with a generic `<repo>:<bits>bit` example
- tell users to select the actual model value via `a2go models`
- add a patch changeset for package `a2go`

## Verification
- ran `uvx --from snyk-agent-scan@latest snyk-agent-scan --skills skills/a2go/SKILL.md`
- current result is clean for `skills/a2go/SKILL.md`
- this change fixes the local Snyk `W012` finding on the skill file
