### PR TITLE
feat(site): platform-first redesign with web platform support

### DIFF
--- a/.changeset/site-platform-redesign.md
+++ b/.changeset/site-platform-redesign.md
@@ -1,0 +1,5 @@
+---
+"a2go": minor
+---
+
+Platform-first redesign with web platform support: renames OsPlatform to Platform, adds web as a new platform, moves platform selector to its own top-level section, adds per-platform draft state persistence, and extracts filter types to model-filters.ts.

--- a/site/src/App.tsx
+++ b/site/src/App.tsx
@@ -3,17 +3,129 @@ import {
   fetchCatalog,
   getTotalVram,
   getDevicesForOs,
+  PLATFORMS,
   type CatalogModel,
   type DeviceInfo,
   type DeviceCount,
-  type OsPlatform,
+  type Platform,
 } from './lib/catalog'
-import { groupModels, buildCatalogEntries, buildFamilyEntries, getVariantForOs, type ModelGroup, type CatalogEntry, type FamilyEntry } from './lib/group-models'
-import { parseUrlState, syncUrlState, clearUrlState, type ModelParam } from './lib/url-state'
+import { groupModels, buildCatalogEntries, buildFamilyEntries, entryHasOs, type ModelGroup, type CatalogEntry, type FamilyEntry } from './lib/group-models'
+import { parseUrlState, syncUrlState, type ModelParam } from './lib/url-state'
+import {
+  createDefaultPlatformDrafts,
+  createEmptyPlatformDraft,
+  DEFAULT_PLATFORM,
+  loadPlatformState,
+  savePlatformState,
+  type PlatformDraft,
+  type PlatformDrafts,
+} from './lib/platform-state'
 import ModelCatalog from './components/ModelCatalog'
 import ConfigPanel from './components/ConfigPanel'
 import { DEFAULT_FRAMEWORK, FRAMEWORKS, type AgentFramework } from './lib/frameworks'
 import { FrameworkPill } from './components/FrameworkSelector'
+
+function resolveFramework(id: string | null | undefined): AgentFramework {
+  return FRAMEWORKS.find((framework) => framework.id === id && framework.available) ?? DEFAULT_FRAMEWORK
+}
+
+function sanitizeDraft(
+  draft: PlatformDraft,
+  models: CatalogModel[],
+  devices: DeviceInfo[],
+  platform: Platform,
+): PlatformDraft {
+  const availableModels = models.filter((model) => model.os.includes(platform))
+  const modelById = new Map(availableModels.map((model) => [model.id, model]))
+  const selectedModelIds: string[] = []
+  const selectedTypes = new Set<CatalogModel['type']>()
+
+  for (const id of draft.selectedModelIds) {
+    const model = modelById.get(id)
+    if (!model || selectedTypes.has(model.type)) continue
+    selectedTypes.add(model.type)
+    selectedModelIds.push(id)
+  }
+
+  const selectedDeviceId = platform !== 'web' && draft.selectedDeviceId && devices.some(
+    (device) => device.id === draft.selectedDeviceId && device.os.includes(platform),
+  )
+    ? draft.selectedDeviceId
+    : null
+
+  return {
+    selectedModelIds,
+    selectedDeviceId,
+    deviceCount: Math.min(8, Math.max(1, Math.trunc(draft.deviceCount || 1))) as DeviceCount,
+    selectedVramGb: platform === 'web' ? null : draft.selectedVramGb,
+    contextOverride: draft.contextOverride,
+    frameworkId: resolveFramework(draft.frameworkId).id,
+  }
+}
+
+function sanitizeDrafts(
+  drafts: PlatformDrafts,
+  models: CatalogModel[],
+  devices: DeviceInfo[],
+): PlatformDrafts {
+  return {
+    mac: sanitizeDraft(drafts.mac, models, devices, 'mac'),
+    linux: sanitizeDraft(drafts.linux, models, devices, 'linux'),
+    windows: sanitizeDraft(drafts.windows, models, devices, 'windows'),
+    web: sanitizeDraft(drafts.web, models, devices, 'web'),
+  }
+}
+
+function findModelForParam(
+  models: CatalogModel[],
+  platform: Platform,
+  type: CatalogModel['type'],
+  param: ModelParam | null,
+): CatalogModel | null {
+  if (!param) return null
+  return models.find((model) =>
+    model.type === type
+    && model.os.includes(platform)
+    && model.repo.toLowerCase() === param.repo.toLowerCase()
+    && (param.bits == null || model.bits === param.bits),
+  ) ?? null
+}
+
+type ModelRole = CatalogModel['type']
+
+interface LogicalSelection {
+  type: ModelRole
+  family: string
+  preferredCatalogKey: string
+  preferredEntryIndex: number
+  preferredSubVariantLabel: string
+}
+
+const MODEL_ROLES: ModelRole[] = ['llm', 'image', 'audio']
+
+function buildDraftFromUrl(
+  models: CatalogModel[],
+  devices: DeviceInfo[],
+  platform: Platform,
+  urlState: ReturnType<typeof parseUrlState>,
+  frameworkId: string,
+): PlatformDraft {
+  const nextDraft = createEmptyPlatformDraft(resolveFramework(urlState.agent ?? frameworkId).id)
+
+  for (const type of ['llm', 'image', 'audio'] as const) {
+    const match = findModelForParam(models, platform, type, urlState[type])
+    if (match) nextDraft.selectedModelIds.push(match.id)
+  }
+
+  if (platform !== 'web' && urlState.device && devices.some((device) => device.id === urlState.device && device.os.includes(platform))) {
+    nextDraft.selectedDeviceId = urlState.device
+  }
+  if (urlState.deviceCount != null) nextDraft.deviceCount = urlState.deviceCount as DeviceCount
+  if (platform !== 'web' && urlState.vram != null) nextDraft.selectedVramGb = urlState.vram
+  if (urlState.ctx != null) nextDraft.contextOverride = urlState.ctx
+
+  return sanitizeDraft(nextDraft, models, devices, platform)
+}
 
 function App() {
   const [allModels, setAllModels] = useState<CatalogModel[]>([])
@@ -21,15 +133,9 @@ function App() {
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
 
-  const [os, setOs] = useState<OsPlatform | null>(null)
-  const [selectedModelIds, setSelectedModelIds] = useState<Set<string>>(new Set())
-  const [selectedDevice, setSelectedDevice] = useState<DeviceInfo | null>(null)
-  const [deviceCount, setDeviceCount] = useState<DeviceCount>(1)
-  const [selectedVramGb, setSelectedVramGb] = useState<number | null>(null)
-  const [contextOverride, setContextOverride] = useState<number | null>(null)
-  const [framework, setFramework] = useState<AgentFramework>(DEFAULT_FRAMEWORK)
+  const [activePlatform, setActivePlatform] = useState<Platform>(DEFAULT_PLATFORM)
+  const [drafts, setDrafts] = useState<PlatformDrafts>(() => createDefaultPlatformDrafts())
 
-  // Track whether URL state has been hydrated to avoid syncing before load
   const hydrated = useRef(false)
 
   useEffect(() => {
@@ -38,34 +144,24 @@ function App() {
         setAllModels(models)
         setAllDevices(devices)
 
-        // Hydrate state from URL after catalog is available
         const url = parseUrlState()
-        if (url.os) setOs(url.os)
-        if (url.agent) {
-          const match = FRAMEWORKS.find((f) => f.id === url.agent && f.available)
-          if (match) setFramework(match)
+        const persisted = loadPlatformState()
+        const persistedDrafts = persisted?.drafts ?? createDefaultPlatformDrafts()
+        const nextPlatform = url.platform ?? persisted?.activePlatform ?? DEFAULT_PLATFORM
+        const nextDrafts = sanitizeDrafts(persistedDrafts, models, devices)
+
+        if (url.hasState) {
+          nextDrafts[nextPlatform] = buildDraftFromUrl(
+            models,
+            devices,
+            nextPlatform,
+            url,
+            nextDrafts[nextPlatform].frameworkId,
+          )
         }
 
-        const ids = new Set<string>()
-        for (const type of ['llm', 'image', 'audio'] as const) {
-          const param = url[type]
-          if (param) {
-            const match = models.find((m) =>
-              m.repo.toLowerCase() === param.repo.toLowerCase() &&
-              (param.bits == null || m.bits === param.bits)
-            )
-            if (match) ids.add(match.id)
-          }
-        }
-        if (ids.size > 0) setSelectedModelIds(ids)
-
-        if (url.device) {
-          const match = devices.find((g) => g.id === url.device)
-          if (match) setSelectedDevice(match)
-        }
-        if (url.deviceCount != null) setDeviceCount(url.deviceCount as DeviceCount)
-        if (url.vram != null) setSelectedVramGb(url.vram)
-        if (url.ctx != null) setContextOverride(url.ctx)
+        setActivePlatform(nextPlatform)
+        setDrafts(nextDrafts)
 
         hydrated.current = true
         setLoading(false)
@@ -76,17 +172,49 @@ function App() {
       })
   }, [])
 
+  const activeDraft = drafts[activePlatform]
+
+  const selectedModelIds = useMemo(
+    () => new Set(activeDraft.selectedModelIds),
+    [activeDraft.selectedModelIds],
+  )
+
+  const modelById = useMemo(
+    () => new Map(allModels.map((model) => [model.id, model])),
+    [allModels],
+  )
+
+  const framework = useMemo(
+    () => resolveFramework(activeDraft.frameworkId),
+    [activeDraft.frameworkId],
+  )
+
+  const selectedDevice = useMemo(() => {
+    if (!activeDraft.selectedDeviceId) return null
+    return allDevices.find((device) =>
+      device.id === activeDraft.selectedDeviceId && device.os.includes(activePlatform),
+    ) ?? null
+  }, [activeDraft.selectedDeviceId, allDevices, activePlatform])
+
+  const selectedModels = useMemo(
+    () => allModels.filter((model) => selectedModelIds.has(model.id)),
+    [allModels, selectedModelIds],
+  )
+
+  const filteredDevices = useMemo(
+    () => getDevicesForOs(activePlatform, allDevices),
+    [activePlatform, allDevices],
+  )
+
   const allGroups = useMemo(() => groupModels(allModels), [allModels])
-
   const allEntries = useMemo(() => buildCatalogEntries(allGroups), [allGroups])
-
   const allFamilyEntries = useMemo(() => buildFamilyEntries(allEntries), [allEntries])
 
   const modelIdToGroup = useMemo(() => {
     const map = new Map<string, ModelGroup>()
     for (const group of allGroups) {
-      for (const v of group.variants) {
-        map.set(v.model.id, group)
+      for (const variant of group.variants) {
+        map.set(variant.model.id, group)
       }
     }
     return map
@@ -94,159 +222,322 @@ function App() {
 
   const modelIdToEntry = useMemo(() => {
     const map = new Map<string, CatalogEntry>()
-    for (const entry of allEntries)
-      for (const group of entry.groups)
-        for (const v of group.variants)
-          map.set(v.model.id, entry)
+    for (const entry of allEntries) {
+      for (const group of entry.groups) {
+        for (const variant of group.variants) {
+          map.set(variant.model.id, entry)
+        }
+      }
+    }
     return map
   }, [allEntries])
 
   const modelIdToFamilyEntry = useMemo(() => {
     const map = new Map<string, FamilyEntry>()
-    for (const fe of allFamilyEntries)
-      for (const entry of fe.entries)
-        for (const group of entry.groups)
-          for (const v of group.variants)
-            map.set(v.model.id, fe)
+    for (const familyEntry of allFamilyEntries) {
+      for (const entry of familyEntry.entries) {
+        for (const group of entry.groups) {
+          for (const variant of group.variants) {
+            map.set(variant.model.id, familyEntry)
+          }
+        }
+      }
+    }
     return map
   }, [allFamilyEntries])
 
-  const filteredDevices = useMemo(() => getDevicesForOs(os, allDevices), [os, allDevices])
-
-  const selectedModels = useMemo(() => {
-    const byId = new Map<string, CatalogModel[]>()
-    for (const m of allModels) {
-      if (!selectedModelIds.has(m.id)) continue
-      const arr = byId.get(m.id) ?? []
-      arr.push(m)
-      byId.set(m.id, arr)
+  const getDraftModelForRole = useCallback((draft: PlatformDraft, role: ModelRole): CatalogModel | null => {
+    for (const id of draft.selectedModelIds) {
+      const model = modelById.get(id)
+      if (model?.type === role) return model
     }
-    return Array.from(byId.values()).map((variants) => {
-      if (variants.length === 1 || !os) return variants[0]
-      return variants.find((v) => v.os.includes(os)) ?? variants[0]
+    return null
+  }, [modelById])
+
+  const getSubVariantLabelForModel = useCallback((modelId: string): string => {
+    const entry = modelIdToEntry.get(modelId)
+    if (!entry) return ''
+    const subVariant = entry.subVariants.find((candidate) =>
+      candidate.groups.some((group) =>
+        group.variants.some((variant) => variant.model.id === modelId),
+      ),
+    )
+    return subVariant?.label ?? ''
+  }, [modelIdToEntry])
+
+  const buildLogicalSelection = useCallback((model: CatalogModel): LogicalSelection | null => {
+    const entry = modelIdToEntry.get(model.id)
+    const familyEntry = modelIdToFamilyEntry.get(model.id)
+    if (!entry || !familyEntry) return null
+
+    return {
+      type: model.type,
+      family: familyEntry.family,
+      preferredCatalogKey: entry.catalogKey,
+      preferredEntryIndex: Math.max(0, familyEntry.entries.findIndex((candidate) => candidate.catalogKey === entry.catalogKey)),
+      preferredSubVariantLabel: getSubVariantLabelForModel(model.id),
+    }
+  }, [getSubVariantLabelForModel, modelIdToEntry, modelIdToFamilyEntry])
+
+  const setDraftRoleModel = useCallback((draft: PlatformDraft, role: ModelRole, modelId: string | null): PlatformDraft => {
+    const nextIds = draft.selectedModelIds.filter((id) => modelById.get(id)?.type !== role)
+    if (modelId) nextIds.push(modelId)
+    return {
+      ...draft,
+      selectedModelIds: nextIds,
+    }
+  }, [modelById])
+
+  const resolveEquivalentModel = useCallback((
+    selection: LogicalSelection,
+    platform: Platform,
+    existingModelId: string | null,
+  ): CatalogModel | null => {
+    const familyEntry = allFamilyEntries.find((entry) => entry.family === selection.family && entry.type === selection.type)
+    if (!familyEntry) return null
+
+    const availableEntries = familyEntry.entries.filter((entry) => entryHasOs(entry, platform))
+    if (availableEntries.length === 0) return null
+
+    const desiredEntry = availableEntries.find((entry) => entry.catalogKey === selection.preferredCatalogKey)
+      ?? availableEntries.reduce((best, candidate) => {
+        const bestIndex = familyEntry.entries.findIndex((entry) => entry.catalogKey === best.catalogKey)
+        const candidateIndex = familyEntry.entries.findIndex((entry) => entry.catalogKey === candidate.catalogKey)
+        return Math.abs(candidateIndex - selection.preferredEntryIndex) < Math.abs(bestIndex - selection.preferredEntryIndex)
+          ? candidate
+          : best
+      }, availableEntries[0])
+
+    const availableSubVariants = desiredEntry.subVariants.filter((subVariant) =>
+      subVariant.groups.some((group) => group.variants.some((variant) => variant.os.includes(platform))),
+    )
+    if (availableSubVariants.length === 0) return null
+
+    const desiredSubVariant = availableSubVariants.find((subVariant) => subVariant.label === selection.preferredSubVariantLabel)
+      ?? availableSubVariants[0]
+
+    if (existingModelId) {
+      const existingModel = modelById.get(existingModelId)
+      if (existingModel?.os.includes(platform)) {
+        const existingEntry = modelIdToEntry.get(existingModel.id)
+        if (existingEntry?.catalogKey === desiredEntry.catalogKey && getSubVariantLabelForModel(existingModel.id) === desiredSubVariant.label) {
+          return existingModel
+        }
+      }
+    }
+
+    const group = desiredSubVariant.groups.find((candidate) =>
+      candidate.variants.some((variant) => variant.os.includes(platform)),
+    )
+    return group ? group.variants.find((variant) => variant.os.includes(platform))?.model ?? null : null
+  }, [allFamilyEntries, getSubVariantLabelForModel, modelById, modelIdToEntry])
+
+  const syncDraftsFromSource = useCallback((draftsToSync: PlatformDrafts, sourceDraft: PlatformDraft): PlatformDrafts => {
+    let nextDrafts: PlatformDrafts = { ...draftsToSync }
+
+    for (const role of MODEL_ROLES) {
+      const sourceModel = getDraftModelForRole(sourceDraft, role)
+      if (!sourceModel) {
+        for (const platform of PLATFORMS) {
+          nextDrafts = {
+            ...nextDrafts,
+            [platform]: setDraftRoleModel(nextDrafts[platform], role, null),
+          }
+        }
+        continue
+      }
+
+      const logicalSelection = buildLogicalSelection(sourceModel)
+      if (!logicalSelection) continue
+
+      for (const platform of PLATFORMS) {
+        const existingModel = getDraftModelForRole(nextDrafts[platform], role)
+        const resolvedModel = resolveEquivalentModel(logicalSelection, platform, existingModel?.id ?? null)
+        nextDrafts = {
+          ...nextDrafts,
+          [platform]: setDraftRoleModel(nextDrafts[platform], role, resolvedModel?.id ?? null),
+        }
+      }
+    }
+
+    return sanitizeDrafts(nextDrafts, allModels, allDevices)
+  }, [allDevices, allModels, buildLogicalSelection, getDraftModelForRole, resolveEquivalentModel, setDraftRoleModel])
+
+  const contextOverride = activeDraft.contextOverride
+  const selectedVramGb = activeDraft.selectedVramGb
+  const deviceCount = activeDraft.deviceCount as DeviceCount
+  const totalVramMb = useMemo(
+    () => getTotalVram(selectedModels, contextOverride),
+    [selectedModels, contextOverride],
+  )
+
+  const updateActiveDraft = useCallback((updater: (draft: PlatformDraft) => PlatformDraft) => {
+    setDrafts((previousDrafts) => ({
+      ...previousDrafts,
+      [activePlatform]: sanitizeDraft(
+        updater(previousDrafts[activePlatform]),
+        allModels,
+        allDevices,
+        activePlatform,
+      ),
+    }))
+  }, [activePlatform, allDevices, allModels])
+
+  const updateGlobalSelectionFromActiveDraft = useCallback((updater: (draft: PlatformDraft) => PlatformDraft) => {
+    setDrafts((previousDrafts) => {
+      const nextActiveDraft = sanitizeDraft(
+        updater(previousDrafts[activePlatform]),
+        allModels,
+        allDevices,
+        activePlatform,
+      )
+
+      return syncDraftsFromSource(
+        {
+          ...previousDrafts,
+          [activePlatform]: nextActiveDraft,
+        },
+        nextActiveDraft,
+      )
     })
-  }, [selectedModelIds, allModels, os])
+  }, [activePlatform, allDevices, allModels, syncDraftsFromSource])
 
-  const totalVramMb = useMemo(() => getTotalVram(selectedModels, contextOverride), [selectedModels, contextOverride])
-
-  // Sync state to URL whenever selections change (after initial hydration)
   useEffect(() => {
     if (!hydrated.current) return
-    function toModelParam(m: CatalogModel | undefined): ModelParam | null {
-      if (!m) return null
-      return { repo: m.repo, bits: m.bits ?? null }
+    savePlatformState({
+      version: 1,
+      activePlatform,
+      drafts,
+    })
+  }, [activePlatform, drafts])
+
+  useEffect(() => {
+    if (!hydrated.current) return
+
+    function toModelParam(model: CatalogModel | undefined): ModelParam | null {
+      if (!model) return null
+      return { repo: model.repo, bits: model.bits ?? null }
     }
-    const llm = selectedModels.find((m) => m.type === 'llm')
-    const image = selectedModels.find((m) => m.type === 'image')
-    const audio = selectedModels.find((m) => m.type === 'audio')
+
     syncUrlState({
-      os,
-      llm: toModelParam(llm),
-      image: toModelParam(image),
-      audio: toModelParam(audio),
+      platform: activePlatform,
+      llm: toModelParam(selectedModels.find((model) => model.type === 'llm')),
+      image: toModelParam(selectedModels.find((model) => model.type === 'image')),
+      audio: toModelParam(selectedModels.find((model) => model.type === 'audio')),
       device: selectedDevice?.id ?? null,
       deviceCount: deviceCount > 1 ? deviceCount : null,
       vram: selectedVramGb,
       ctx: contextOverride,
       agent: framework.id,
+      hasState: true,
     })
-  }, [os, selectedModels, selectedDevice, deviceCount, selectedVramGb, contextOverride, framework])
+  }, [activePlatform, selectedModels, selectedDevice, deviceCount, selectedVramGb, contextOverride, framework])
 
-  const toggleModel = useCallback(
-    (model: CatalogModel) => {
-      setSelectedModelIds((prev) => {
-        const next = new Set(prev)
-        if (next.has(model.id)) {
-          next.delete(model.id)
-        } else {
-          const sameCategoryIds = allModels
-            .filter((m) => m.type === model.type)
-            .map((m) => m.id)
-          for (const id of sameCategoryIds) {
-            next.delete(id)
-          }
-          next.add(model.id)
+  const toggleModel = useCallback((model: CatalogModel) => {
+    updateGlobalSelectionFromActiveDraft((draft) => {
+      const nextIds = new Set(draft.selectedModelIds)
+      if (nextIds.has(model.id)) {
+        nextIds.delete(model.id)
+      } else {
+        for (const existingModel of allModels) {
+          if (existingModel.type === model.type) nextIds.delete(existingModel.id)
         }
-        return next
-      })
-      if (model.type === 'llm') setContextOverride(null)
-    },
-    [allModels]
-  )
+        nextIds.add(model.id)
+      }
+
+      return {
+        ...draft,
+        selectedModelIds: Array.from(nextIds),
+        contextOverride: model.type === 'llm' ? null : draft.contextOverride,
+      }
+    })
+  }, [allModels, updateGlobalSelectionFromActiveDraft])
 
   const swapModelVariant = useCallback((oldModel: CatalogModel, newModel: CatalogModel) => {
-    setSelectedModelIds(prev => {
-      const next = new Set(prev)
-      next.delete(oldModel.id)
-      next.add(newModel.id)
-      return next
+    const oldLogical = buildLogicalSelection(oldModel)
+    const newLogical = buildLogicalSelection(newModel)
+    const isSameLogicalSelection = oldLogical && newLogical
+      && oldLogical.family === newLogical.family
+      && oldLogical.preferredCatalogKey === newLogical.preferredCatalogKey
+      && oldLogical.preferredSubVariantLabel === newLogical.preferredSubVariantLabel
+
+    const updater = (draft: PlatformDraft) => ({
+      ...draft,
+      selectedModelIds: draft.selectedModelIds
+        .filter((id) => id !== oldModel.id)
+        .concat(newModel.id),
     })
-  }, [])
+
+    if (isSameLogicalSelection) {
+      updateActiveDraft(updater)
+    } else {
+      updateGlobalSelectionFromActiveDraft(updater)
+    }
+  }, [buildLogicalSelection, updateActiveDraft, updateGlobalSelectionFromActiveDraft])
 
   const handleDeviceSelect = useCallback((device: DeviceInfo) => {
-    setSelectedDevice((prev) => {
-      if (prev?.id === device.id) {
-        setDeviceCount(1) // reset count when deselecting
-        return null
-      }
-      return device
-    })
-    setSelectedVramGb(null)
-  }, [])
+    updateActiveDraft((draft) => ({
+      ...draft,
+      selectedDeviceId: draft.selectedDeviceId === device.id ? null : device.id,
+      deviceCount: draft.selectedDeviceId === device.id ? 1 : draft.deviceCount,
+      selectedVramGb: null,
+    }))
+  }, [updateActiveDraft])
 
   const handleDeviceCountChange = useCallback((count: DeviceCount) => {
-    setDeviceCount(count)
-  }, [])
+    updateActiveDraft((draft) => ({
+      ...draft,
+      deviceCount: count,
+    }))
+  }, [updateActiveDraft])
 
   const handleVramPreset = useCallback((gb: number) => {
-    setSelectedVramGb((prev) => (prev === gb ? null : gb))
-    setSelectedDevice(null)
-    setDeviceCount(1)
-  }, [])
+    updateActiveDraft((draft) => ({
+      ...draft,
+      selectedVramGb: draft.selectedVramGb === gb ? null : gb,
+      selectedDeviceId: null,
+      deviceCount: 1,
+    }))
+  }, [updateActiveDraft])
 
-  const handleOsChange = useCallback((newOs: OsPlatform) => {
-    const nextOs = os === newOs ? null : newOs
-    setOs(nextOs)
-
-    setSelectedModelIds((prevIds) => {
-      if (prevIds.size === 0) return prevIds
-      const next = new Set<string>()
-      for (const id of prevIds) {
-        const group = modelIdToGroup.get(id)
-        if (group) {
-          const variant = getVariantForOs(group, nextOs)
-          next.add(variant.model.id)
-        }
-      }
-      return next
-    })
-
-    setSelectedDevice(null)
-    setSelectedVramGb(null)
-  }, [os, modelIdToGroup])
+  const handlePlatformChange = useCallback((platform: Platform) => {
+    setDrafts((previousDrafts) => syncDraftsFromSource(previousDrafts, previousDrafts[activePlatform]))
+    setActivePlatform(platform)
+  }, [activePlatform, syncDraftsFromSource])
 
   const handleClearAll = useCallback(() => {
-    setSelectedModelIds(new Set())
-    setOs(null)
-    setSelectedDevice(null)
-    setDeviceCount(1)
-    setSelectedVramGb(null)
-    setContextOverride(null)
-    clearUrlState()
-  }, [])
+    updateActiveDraft((draft) => ({
+      ...createEmptyPlatformDraft(draft.frameworkId),
+      frameworkId: draft.frameworkId,
+    }))
+  }, [updateActiveDraft])
+
+  const handleFrameworkSelect = useCallback((nextFramework: AgentFramework) => {
+    updateActiveDraft((draft) => ({
+      ...draft,
+      frameworkId: nextFramework.id,
+    }))
+  }, [updateActiveDraft])
+
+  const handleContextChange = useCallback((ctx: number | null) => {
+    updateActiveDraft((draft) => ({
+      ...draft,
+      contextOverride: ctx,
+    }))
+  }, [updateActiveDraft])
 
   const effectiveVramGb = selectedVramGb ?? (selectedDevice ? (selectedDevice.vramMb * deviceCount) / 1024 : 0)
   const effectiveVramMb = effectiveVramGb * 1024
   const remainingVramMb = effectiveVramMb > 0 ? effectiveVramMb - totalVramMb : 0
 
-  const hasSelections = selectedModels.length > 0 || os !== null || selectedDevice !== null || deviceCount > 1 || selectedVramGb !== null
+  const hasSelections = selectedModels.length > 0 || selectedDevice !== null || deviceCount > 1 || selectedVramGb !== null
 
   if (error) {
     return (
       <div className="flex h-screen w-screen items-center justify-center bg-background">
         <div className="text-center">
-          <div className="font-mono text-sm text-destructive tracking-wider mb-2">error</div>
-          <p className="text-foreground/40 text-sm">{error}</p>
+          <div className="mb-2 font-mono text-sm tracking-wider text-destructive">error</div>
+          <p className="text-sm text-foreground/40">{error}</p>
         </div>
       </div>
     )
@@ -256,16 +547,15 @@ function App() {
     return (
       <div className="flex h-screen w-screen items-center justify-center bg-background">
         <div className="text-center">
-          <p className="font-mono text-foreground/20 text-xs tracking-wider animate-pulse-subtle">loading registry</p>
+          <p className="animate-pulse-subtle font-mono text-xs tracking-wider text-foreground/20">loading registry</p>
         </div>
       </div>
     )
   }
 
   return (
-    <div className="noise-bg flex min-h-screen lg:h-screen w-screen flex-col lg:flex-row lg:overflow-hidden bg-background">
-      {/* Mobile header — logo + framework pill */}
-      <div className="flex lg:hidden shrink-0 items-center justify-between border-b border-foreground/[0.06] px-4 py-2">
+    <div className="noise-bg flex min-h-screen w-screen flex-col bg-background lg:h-screen lg:flex-row lg:overflow-hidden">
+      <div className="flex shrink-0 items-center justify-between border-b border-foreground/[0.06] px-4 py-2 lg:hidden">
         <a
           href="https://github.com/runpod-labs/a2go"
           target="_blank"
@@ -283,15 +573,13 @@ function App() {
             agent2go
           </span>
         </a>
-        <FrameworkPill selected={framework} onSelect={setFramework} />
+        <FrameworkPill selected={framework} onSelect={handleFrameworkSelect} />
       </div>
 
-      {/* On mobile: both panels render in a single scrollable column.
-          On desktop (lg+): side-by-side layout as before. */}
       <ModelCatalog
         familyEntries={allFamilyEntries}
-        os={os}
-        onOsChange={handleOsChange}
+        platform={activePlatform}
+        onPlatformChange={handlePlatformChange}
         selectedModelIds={selectedModelIds}
         selectedModels={selectedModels}
         onToggleModel={toggleModel}
@@ -300,7 +588,7 @@ function App() {
         onClearAll={handleClearAll}
         hasSelections={hasSelections}
         framework={framework}
-        onFrameworkSelect={setFramework}
+        onFrameworkSelect={handleFrameworkSelect}
       />
       <ConfigPanel
         selectedModels={selectedModels}
@@ -316,10 +604,10 @@ function App() {
         modelIdToGroup={modelIdToGroup}
         modelIdToEntry={modelIdToEntry}
         modelIdToFamilyEntry={modelIdToFamilyEntry}
-        os={os}
+        platform={activePlatform}
         hasSelections={hasSelections}
         contextOverride={contextOverride}
-        onContextChange={setContextOverride}
+        onContextChange={handleContextChange}
         swapModelVariant={swapModelVariant}
         framework={framework}
       />

--- a/site/src/components/ConfigPanel.tsx
+++ b/site/src/components/ConfigPanel.tsx
@@ -6,7 +6,7 @@ import VramGauge, { type VramSegment } from './VramSelector'
 import SelectedModels from './SelectedModels'
 import DeployCard from './DeployOutput'
 import SecurityGuide from './SecurityGuide'
-import type { CatalogModel, DeviceInfo, DeviceCount, OsPlatform } from '../lib/catalog'
+import type { CatalogModel, DeviceInfo, DeviceCount, Platform } from '../lib/catalog'
 import { VRAM_PRESETS } from '../lib/catalog'
 import { getVariantForOs, type ModelGroup, type CatalogEntry, type FamilyEntry } from '../lib/group-models'
 import type { AgentFramework } from '../lib/frameworks'
@@ -51,7 +51,7 @@ export default function ConfigPanel({
   modelIdToGroup,
   modelIdToEntry,
   modelIdToFamilyEntry,
-  os,
+  platform,
   hasSelections,
   contextOverride,
   onContextChange,
@@ -71,7 +71,7 @@ export default function ConfigPanel({
   modelIdToGroup: Map<string, ModelGroup>
   modelIdToEntry?: Map<string, CatalogEntry>
   modelIdToFamilyEntry?: Map<string, FamilyEntry>
-  os: OsPlatform | null
+  platform: Platform
   hasSelections: boolean
   contextOverride: number | null
   onContextChange: (ctx: number | null) => void
@@ -79,12 +79,13 @@ export default function ConfigPanel({
   framework: AgentFramework
 }) {
   const hasModels = selectedModels.length > 0
+  const showResourcePanels = platform !== 'web'
 
   // Track the active platform tab from SelectedModels (card-local, never affects global OS)
-  const [sharedOs, setSharedOs] = useState<OsPlatform | null>(os)
+  const [sharedOs, setSharedOs] = useState<Platform | null>(platform)
 
-  // Sync shared tab state when global OS is set; preserve user's tab selection when cleared
-  useEffect(() => { if (os != null) setSharedOs(os) }, [os])
+  // Keep card-local platform state aligned with the active global platform.
+  useEffect(() => { setSharedOs(platform) }, [platform])
 
   // Per-type VRAM segments for the gauge bar — use the variant matching the active tab,
   // so switching platform tabs in a card immediately updates the memory gauge.
@@ -136,8 +137,7 @@ export default function ConfigPanel({
 
   return (
     <div className="flex flex-1 min-h-0 flex-col overflow-visible lg:overflow-y-scroll">
-      {/* Memory — collapsible on mobile, inline on desktop */}
-      <CollapsibleSection title="Memory" badge={memoryBadge}>
+      {showResourcePanels && <CollapsibleSection title="Memory" badge={memoryBadge}>
         {/* Desktop: toolbar grid row with Memory + Hardware + Logo */}
         <div className="hidden lg:block">
           <div className="border-b border-foreground/[0.06]">
@@ -223,10 +223,10 @@ export default function ConfigPanel({
             segments={vramSegments}
           />
         </div>
-      </CollapsibleSection>
+      </CollapsibleSection>}
 
       {/* Hardware — collapsible on mobile only (desktop is rendered above inside the grid) */}
-      <div className="lg:hidden">
+      {showResourcePanels && <div className="lg:hidden">
         <CollapsibleSection title="Hardware" badge={hardwareBadge}>
           <div className="flex items-center gap-1 border-b border-foreground/[0.04] px-3 py-1.5">
             <span className="font-mono text-[8px] uppercase tracking-widest text-foreground/25">
@@ -244,7 +244,7 @@ export default function ConfigPanel({
             />
           </div>
         </CollapsibleSection>
-      </div>
+      </div>}
 
       {/* Selected Models — sticky header */}
       <div className="sticky top-0 z-10 bg-background border-b border-foreground/[0.06]">
@@ -285,7 +285,7 @@ export default function ConfigPanel({
           modelIdToEntry={modelIdToEntry}
           modelIdToFamilyEntry={modelIdToFamilyEntry}
           devices={devices}
-          os={os}
+          os={platform}
           contextOverride={contextOverride}
           onContextChange={onContextChange}
           onSharedOsChange={setSharedOs}
@@ -323,7 +323,7 @@ export default function ConfigPanel({
                 <DeployCard
                   selectedModels={selectedModels}
                   modelIdToGroup={modelIdToGroup}
-                  globalOs={os}
+                  globalOs={sharedOs}
                   contextOverride={contextOverride}
                   onToggle={onToggleModel}
                   framework={framework}

--- a/site/src/components/DeployOutput.tsx
+++ b/site/src/components/DeployOutput.tsx
@@ -1,6 +1,6 @@
 import { useState, useMemo, useEffect } from 'react'
 import { cn } from '../lib/utils'
-import { formatVram, type CatalogModel, type OsPlatform } from '../lib/catalog'
+import { formatVram, type CatalogModel, type Platform } from '../lib/catalog'
 import { getVariantForOs, findSiblingsWithOs, type ModelGroup } from '../lib/group-models'
 import type { AgentFramework } from '../lib/frameworks'
 import { PlatformIcon } from './PlatformSelector'
@@ -132,7 +132,7 @@ export function CodeBlock({ code, requirements }: { code: string; requirements: 
   )
 }
 
-const TAB_CONFIG: { id: DeployTab; label: string; os: OsPlatform | null; icon?: 'agent' | 'cloud' }[] = [
+const TAB_CONFIG: { id: DeployTab; label: string; os: Platform | null; icon?: 'agent' | 'cloud' }[] = [
   { id: 'agent', label: 'agent', os: null, icon: 'agent' },
   { id: 'linux', label: 'linux', os: 'linux' },
   { id: 'windows', label: 'windows', os: 'windows' },
@@ -140,9 +140,10 @@ const TAB_CONFIG: { id: DeployTab; label: string; os: OsPlatform | null; icon?: 
   { id: 'cloud', label: 'cloud', os: null, icon: 'cloud' },
 ]
 
-function isTabVisible(tab: DeployTab, os: OsPlatform | null): boolean {
+function isTabVisible(tab: DeployTab, os: Platform | null): boolean {
   if (tab === 'agent') return true
   if (os === null) return true
+  if (os === 'web') return false
   if (tab === 'cloud') return os !== 'mac'
   if (tab === 'linux') return os === 'linux'
   if (tab === 'windows') return os === 'windows'
@@ -568,7 +569,7 @@ export default function DeployCard({
 }: {
   selectedModels: CatalogModel[]
   modelIdToGroup: Map<string, ModelGroup>
-  globalOs: OsPlatform | null
+  globalOs: Platform | null
   contextOverride: number | null
   onToggle?: (model: CatalogModel) => void
   framework: AgentFramework

--- a/site/src/components/ModelCatalog.tsx
+++ b/site/src/components/ModelCatalog.tsx
@@ -2,13 +2,15 @@ import { useMemo, useCallback, useState } from 'react'
 import { ChevronUp, ChevronDown } from 'lucide-react'
 import CollapsibleSection from './CollapsibleSection'
 import ModelSearch from './ModelSearch'
-import ModelFilters, { type FilterState, type TaskChip, EMPTY_FILTERS } from './ModelFilters'
+import ModelFilters from './ModelFilters'
 import CatalogEntryCard from './ModelPicker'
 import SectionHeader from './SectionHeader'
 import FrameworkSelector from './FrameworkSelector'
-import type { CatalogModel, OsPlatform } from '../lib/catalog'
+import PlatformSelector from './PlatformSelector'
+import type { CatalogModel, Platform } from '../lib/catalog'
 import type { AgentFramework } from '../lib/frameworks'
-import { getFamilyEntrySummary, getVariantForOs, type FamilyEntry } from '../lib/group-models'
+import { EMPTY_FILTERS, type FilterState, type TaskChip } from '../lib/model-filters'
+import { familyEntryHasOs, getFamilyEntrySummary, getVariantForOs, type FamilyEntry } from '../lib/group-models'
 
 type SortColumn = 'name' | 'ctx' | 'tps' | 'memory'
 type SortDirection = 'asc' | 'desc'
@@ -65,8 +67,8 @@ function SortableColumnHeader({
 
 export default function ModelCatalog({
   familyEntries,
-  os,
-  onOsChange,
+  platform,
+  onPlatformChange,
   selectedModelIds,
   selectedModels,
   onToggleModel,
@@ -78,8 +80,8 @@ export default function ModelCatalog({
   onFrameworkSelect,
 }: {
   familyEntries: FamilyEntry[]
-  os: OsPlatform | null
-  onOsChange: (os: OsPlatform) => void
+  platform: Platform
+  onPlatformChange: (platform: Platform) => void
   selectedModelIds: Set<string>
   selectedModels: CatalogModel[]
   onToggleModel: (model: CatalogModel) => void
@@ -103,22 +105,16 @@ export default function ModelCatalog({
 
   const searchLower = search.toLowerCase().trim()
 
-  const lockedTypes = useMemo(() => {
-    const types = new Set<string>()
-    for (const m of selectedModels) types.add(m.type)
-    return types
-  }, [selectedModels])
-
   const visibleTypes = useMemo(() => getVisibleTypes(filters.task), [filters.task])
 
   /** Pre-compute summaries for all family entries */
   const summaryMap = useMemo(() => {
     const map = new Map<string, { maxTps?: number; minVramMb: number }>()
     for (const fe of familyEntries) {
-      map.set(fe.family, getFamilyEntrySummary(fe, os))
+      map.set(fe.family, getFamilyEntrySummary(fe, platform))
     }
     return map
-  }, [familyEntries, os])
+  }, [familyEntries, platform])
 
   /** Sort filtered entries by the active column/direction */
   const sortEntries = useCallback(
@@ -167,7 +163,7 @@ export default function ModelCatalog({
   const filterEntries = useCallback(
     (allFamilies: FamilyEntry[], type: SectionKey): FamilyEntry[] => {
       if (!visibleTypes.has(type)) return []
-      let result = allFamilies.filter((fe) => fe.type === type)
+      let result = allFamilies.filter((fe) => fe.type === type && familyEntryHasOs(fe, platform))
       if (searchLower) {
         result = result.filter(
           (fe) =>
@@ -191,7 +187,7 @@ export default function ModelCatalog({
       }
       return result
     },
-    [searchLower, filters, visibleTypes]
+    [searchLower, filters, visibleTypes, platform]
   )
 
   const modelSections = useMemo(
@@ -230,19 +226,19 @@ export default function ModelCatalog({
 
       // First group with a variant for current OS (smallest bits first)
       let bestGroup = sv.groups.find((g) =>
-        g.variants.some((v) => !os || v.os.includes(os))
+        g.variants.some((v) => v.os.includes(platform))
       )
       // Fall back to first group
       if (!bestGroup) bestGroup = sv.groups[0]
       if (!bestGroup) return
 
-      const variant = getVariantForOs(bestGroup, os)
+      const variant = getVariantForOs(bestGroup, platform)
       onToggleModel(variant.model)
     },
-    [os, selectedModelIds, onToggleModel]
+    [platform, selectedModelIds, onToggleModel]
   )
 
-  const hasActiveFilters = hasSelections || os !== null || filters.task !== null || filters.contextMin !== null || search !== "" || sort.column !== 'name' || sort.direction !== 'asc'
+  const hasActiveFilters = hasSelections || filters.task !== null || filters.contextMin !== null || search !== "" || sort.column !== 'name' || sort.direction !== 'asc'
 
   const handleReset = useCallback(() => {
     setSearch("")
@@ -269,6 +265,15 @@ export default function ModelCatalog({
         <FrameworkSelector selected={framework} onSelect={onFrameworkSelect} />
       </div>
 
+      <div className="border-b border-foreground/[0.06]">
+        <SectionHeader>
+          <span className="font-mono text-[10px] font-bold uppercase tracking-[0.2em] text-foreground/70">
+            Platform
+          </span>
+        </SectionHeader>
+        <PlatformSelector os={platform} onChange={onPlatformChange} />
+      </div>
+
       <CollapsibleSection title="Models" badge={modelsBadge} className="lg:flex-1 lg:min-h-0 flex flex-col">
         <SectionHeader className="hidden lg:flex">
           <span className="font-mono text-[10px] font-bold uppercase tracking-[0.2em] text-foreground/70">
@@ -284,12 +289,7 @@ export default function ModelCatalog({
           )}
         </SectionHeader>
         <ModelSearch value={search} onChange={setSearch} />
-        <ModelFilters
-          filters={filters}
-          onChange={setFilters}
-          os={os}
-          onOsChange={onOsChange}
-        />
+        <ModelFilters filters={filters} onChange={setFilters} />
 
         {/* column headers */}
         <div className="flex shrink-0 items-center gap-2 border-b border-foreground/[0.04] px-3 py-1.5">
@@ -303,7 +303,11 @@ export default function ModelCatalog({
         <div className="overflow-y-auto py-1 max-h-[50vh] lg:max-h-none lg:flex-1" data-model-list>
           {modelSections.length === 0 && (
             <div className="flex items-center justify-center py-12">
-              <span className="font-mono text-[10px] text-foreground/30">no models match</span>
+              <span className="font-mono text-[10px] text-foreground/30">
+                {search || filters.task || filters.contextMin
+                  ? 'no models match'
+                  : `no models for ${platform} yet`}
+              </span>
             </div>
           )}
           {modelSections.map((section) => (
@@ -323,8 +327,6 @@ export default function ModelCatalog({
                   effectiveVramMb > 0 &&
                   !selected &&
                   summary.minVramMb > remainingVramMb
-                const dimmed = !selected && lockedTypes.has(fe.type)
-
                 return (
                   <CatalogEntryCard
                     key={fe.family}
@@ -332,8 +334,7 @@ export default function ModelCatalog({
                     selected={selected}
                     onToggle={() => handleFamilyToggle(fe)}
                     wouldExceed={wouldExceed}
-                    dimmed={dimmed}
-                    os={os}
+                    os={platform}
                     accentColor={section.color}
                   />
                 )

--- a/site/src/components/ModelFilters.tsx
+++ b/site/src/components/ModelFilters.tsx
@@ -1,20 +1,7 @@
 import { useState } from 'react'
 import * as Popover from '@radix-ui/react-popover'
 import { cn } from '../lib/utils'
-import { OsPills } from './PlatformSelector'
-import type { OsPlatform } from '../lib/catalog'
-
-export type TaskChip = 'llm' | 'vision' | 'image' | 'audio'
-
-export interface FilterState {
-  contextMin: number | null
-  task: TaskChip | null
-}
-
-export const EMPTY_FILTERS: FilterState = {
-  contextMin: null,
-  task: null,
-}
+import type { FilterState, TaskChip } from '../lib/model-filters'
 
 export const CONTEXT_TIERS = [
   { label: '32k', value: 32_000 },
@@ -90,13 +77,9 @@ function ContextPicker({
 export default function ModelFilters({
   filters,
   onChange,
-  os,
-  onOsChange,
 }: {
   filters: FilterState
   onChange: (filters: FilterState) => void
-  os: OsPlatform | null
-  onOsChange: (os: OsPlatform) => void
 }) {
   const handleTaskClick = (chip: TaskChip) => {
     const nextTask = filters.task === chip ? null : chip
@@ -106,10 +89,6 @@ export default function ModelFilters({
 
   return (
     <div className="flex shrink-0 items-center gap-1 border-b border-foreground/[0.06] px-3 py-1.5">
-      <OsPills os={os} onChange={onOsChange} />
-
-      <div className="h-3.5 w-px shrink-0 bg-foreground/[0.08]" />
-
       {TASK_CHIPS.map((chip) => (
         <button
           key={chip}

--- a/site/src/components/ModelPicker.tsx
+++ b/site/src/components/ModelPicker.tsx
@@ -9,7 +9,6 @@ export default function CatalogEntryCard({
   selected,
   onToggle,
   wouldExceed,
-  dimmed,
   os,
   accentColor,
 }: {
@@ -17,16 +16,19 @@ export default function CatalogEntryCard({
   selected: boolean
   onToggle: () => void
   wouldExceed: boolean
-  dimmed: boolean
   os: OsPlatform | null
   accentColor: string
 }) {
   const summary = getFamilyEntrySummary(familyEntry, os)
+  const selectedBackground = `${accentColor}1f`
+  const selectedBorder = `${accentColor}66`
+  const selectedBadgeBackground = `${accentColor}26`
 
   return (
     <div
       role="button"
       tabIndex={0}
+      aria-pressed={selected}
       onClick={onToggle}
       onKeyDown={(e) => {
         if (e.key === "Enter" || e.key === " ") {
@@ -57,16 +59,15 @@ export default function CatalogEntryCard({
       }}
       className={cn(
         "group flex w-full cursor-pointer items-center text-left transition-all duration-150",
-        "h-10 px-3 gap-2",
+        "h-10 gap-2 border-l-3 px-3",
         selected
-          ? "bg-foreground/[0.07]"
-          : "hover:bg-foreground/[0.03]",
+          ? "border-transparent"
+          : "border-transparent hover:bg-foreground/[0.03]",
         wouldExceed && !selected && "pointer-events-none opacity-20",
-        dimmed && !selected && "opacity-35",
       )}
       data-model-type={familyEntry.type}
       data-selected={selected || undefined}
-      style={selected ? { boxShadow: `inset 3px 0 0 ${accentColor}` } : undefined}
+      style={selected ? { backgroundColor: selectedBackground, borderLeftColor: accentColor, boxShadow: `inset 0 0 0 1px ${selectedBorder}` } : undefined}
     >
       {/* model name */}
       <span
@@ -80,27 +81,51 @@ export default function CatalogEntryCard({
         {familyEntry.displayName}
       </span>
 
+      {selected && (
+        <span
+          className="shrink-0 rounded-full px-1.5 py-0.5 font-mono text-[8px] font-bold uppercase tracking-[0.16em] text-foreground/90"
+          style={{ backgroundColor: selectedBadgeBackground, color: accentColor }}
+        >
+          selected
+        </span>
+      )}
+
       {/* vision badge */}
       {familyEntry.hasVision && (
-        <span className="shrink-0 bg-foreground/[0.04] px-1.5 py-0.5 font-mono text-[8px] font-medium text-foreground/50">
+        <span className={cn(
+          "shrink-0 px-1.5 py-0.5 font-mono text-[8px] font-medium",
+          selected ? "bg-foreground/[0.06] text-foreground/70" : "bg-foreground/[0.04] text-foreground/50",
+        )}>
           vision
         </span>
       )}
 
       {/* capability badges (tts, stt) */}
       {familyEntry.capabilities?.map((cap) => (
-        <span key={cap} className="shrink-0 bg-foreground/[0.04] px-1.5 py-0.5 font-mono text-[8px] font-medium text-foreground/50">
+        <span
+          key={cap}
+          className={cn(
+            "shrink-0 px-1.5 py-0.5 font-mono text-[8px] font-medium",
+            selected ? "bg-foreground/[0.06] text-foreground/70" : "bg-foreground/[0.04] text-foreground/50",
+          )}
+        >
           {cap}
         </span>
       ))}
 
       {/* context */}
-      <span className="w-[36px] shrink-0 text-right font-mono text-[10px] tabular-nums text-foreground/60">
+      <span className={cn(
+        "w-[36px] shrink-0 text-right font-mono text-[10px] tabular-nums",
+        selected ? "text-foreground/85" : "text-foreground/60",
+      )}>
         {familyEntry.maxContextLength ? formatContext(familyEntry.maxContextLength) : "--"}
       </span>
 
       {/* tps */}
-      <span className="w-[36px] shrink-0 text-right font-mono text-[10px] tabular-nums text-foreground/60">
+      <span className={cn(
+        "w-[36px] shrink-0 text-right font-mono text-[10px] tabular-nums",
+        selected ? "text-foreground/85" : "text-foreground/60",
+      )}>
         {summary.maxTps != null ? summary.maxTps : "--"}
       </span>
 

--- a/site/src/components/PlatformSelector.tsx
+++ b/site/src/components/PlatformSelector.tsx
@@ -1,29 +1,33 @@
 import { cn } from '../lib/utils'
-import type { OsPlatform } from '../lib/catalog'
+import type { Platform } from '../lib/catalog'
 import type { ReactNode } from 'react'
 import { FaLinux, FaWindows, FaApple } from 'react-icons/fa'
+import { Globe } from 'lucide-react'
 
-function PlatformIcon({ os, className }: { os: OsPlatform; className?: string }): ReactNode {
+function PlatformIcon({ os, className }: { os: Platform; className?: string }): ReactNode {
+  if (os === 'web') return <Globe className={className} />
   if (os === 'linux') return <FaLinux className={className} />
   if (os === 'windows') return <FaWindows className={className} />
   return <FaApple className={className} />
 }
 
-const OS_OPTIONS: { id: OsPlatform; label: string }[] = [
-  { id: "linux", label: "Linux" },
-  { id: "windows", label: "Windows" },
-  { id: "mac", label: "macOS" },
+const OS_OPTIONS: { id: Platform; label: string }[] = [
+  { id: 'mac', label: 'macOS' },
+  { id: 'linux', label: 'Linux' },
+  { id: 'windows', label: 'Windows' },
+  { id: 'web', label: 'Web' },
 ]
 
-const OS_ACTIVE_STYLES: Record<OsPlatform, string> = {
-  linux: "bg-[#E8B931] text-[#1a1a1a]",
-  windows: "bg-[#0078D4] text-white",
-  mac: "bg-[#A2AAAD] text-[#1a1a1a]",
+const OS_ACTIVE_STYLES: Record<Platform, string> = {
+  linux: 'bg-[#E8B931] text-[#1a1a1a]',
+  windows: 'bg-[#0078D4] text-white',
+  mac: 'bg-[#A2AAAD] text-[#1a1a1a]',
+  web: 'bg-[#71E4FF] text-[#06131A]',
 }
 
 export { PlatformIcon }
 
-export function OsPills({ os, onChange }: { os: OsPlatform | null; onChange: (os: OsPlatform) => void }) {
+export function PlatformPills({ os, onChange }: { os: Platform; onChange: (os: Platform) => void }) {
   return (
     <div className="flex items-center gap-0.5">
       {OS_OPTIONS.map((opt) => {
@@ -52,11 +56,11 @@ export default function PlatformSelector({
   os,
   onChange,
 }: {
-  os: OsPlatform | null
-  onChange: (os: OsPlatform) => void
+  os: Platform
+  onChange: (os: Platform) => void
 }) {
   return (
-    <div className="flex shrink-0 border-b border-foreground/[0.06]">
+    <div className="grid grid-cols-2 lg:grid-cols-4">
       {OS_OPTIONS.map((opt) => {
         const active = os === opt.id
         return (
@@ -64,15 +68,19 @@ export default function PlatformSelector({
             key={opt.id}
             onClick={() => onChange(opt.id)}
             className={cn(
-              "flex flex-1 items-center justify-center gap-2 py-2.5 font-mono text-[11px] font-medium tracking-wide transition-all duration-200",
+              "flex items-center justify-center gap-1.5 border-foreground/[0.06] py-3 font-mono transition-colors",
+              opt.id !== 'web' && 'lg:border-r',
+              opt.id === 'mac' || opt.id === 'linux' ? 'border-b lg:border-b-0' : '',
+              opt.id === 'mac' || opt.id === 'windows' ? 'border-r lg:border-r-0' : '',
               active
                 ? OS_ACTIVE_STYLES[opt.id]
-                : "text-foreground/70 hover:bg-foreground/[0.03] hover:text-foreground",
-              opt.id !== "mac" && "border-r border-foreground/[0.06]"
+                : "bg-transparent text-foreground/60 hover:bg-foreground/[0.04] hover:text-foreground/80"
             )}
           >
-            <PlatformIcon os={opt.id} className="h-3.5 w-3.5" />
-            {opt.label}
+            <span className="flex items-center gap-1.5 text-[11px] font-semibold tracking-tight">
+              <PlatformIcon os={opt.id} className="h-3 w-3" />
+              {opt.label}
+            </span>
           </button>
         )
       })}

--- a/site/src/lib/catalog.ts
+++ b/site/src/lib/catalog.ts
@@ -3,7 +3,9 @@ export interface ModelVram {
   overhead: number
 }
 
-export type OsPlatform = 'linux' | 'windows' | 'mac'
+export const PLATFORMS = ['mac', 'linux', 'windows', 'web'] as const
+export type Platform = (typeof PLATFORMS)[number]
+export type OsPlatform = Platform
 
 export interface CatalogModel {
   id: string
@@ -22,7 +24,7 @@ export interface CatalogModel {
   kvCacheMbPer1kTokens?: number
   contextLength?: number
   tps?: Record<string, number>
-  os: OsPlatform[]
+  os: Platform[]
   isDefault: boolean
   hasVision: boolean
   capabilities?: string[]
@@ -32,7 +34,7 @@ export interface DeviceInfo {
   id: string
   name: string
   vramMb: number
-  os: OsPlatform[]
+  os: Platform[]
 }
 
 const MAC_DEVICES: DeviceInfo[] = [
@@ -133,7 +135,8 @@ interface RawModel {
   tps?: Record<string, number>
   defaults?: { contextLength?: number }
   mmproj?: string
-  platform?: 'nvidia' | 'mlx'
+  platform?: string
+  platforms?: Platform[]
   [key: string]: unknown
 }
 
@@ -149,6 +152,28 @@ interface RawCatalog {
   gpus: RawDevice[]
 }
 
+function resolveModelPlatforms(model: RawModel): Platform[] {
+  const declared = Array.isArray(model.platforms)
+    ? model.platforms.filter((platform): platform is Platform => PLATFORMS.includes(platform))
+    : []
+  if (declared.length > 0) return declared
+
+  switch (model.platform) {
+    case 'mlx':
+    case 'mac':
+      return ['mac']
+    case 'linux':
+      return ['linux']
+    case 'windows':
+      return ['windows']
+    case 'web':
+      return ['web']
+    case 'nvidia':
+    default:
+      return ['linux', 'windows']
+  }
+}
+
 export async function fetchCatalog(): Promise<{ models: CatalogModel[]; devices: DeviceInfo[] }> {
   const res = await fetch(`${import.meta.env.BASE_URL}v1/catalog.json`)
   if (!res.ok) throw new Error(`Failed to load catalog: ${res.status}`)
@@ -157,34 +182,7 @@ export async function fetchCatalog(): Promise<{ models: CatalogModel[]; devices:
   const models: CatalogModel[] = raw.models.flatMap((m) => {
     const hasVision = typeof m.mmproj === 'string' && m.mmproj.length > 0
 
-    // MLX-only models (platform: "mlx") → Mac tab only
-    if (m.platform === 'mlx') {
-      return [{
-        id: m.id,
-        group: m.group,
-        family: m.family,
-        catalogKey: m.catalogKey,
-        name: m.name.toLowerCase(),
-        size: m.size ?? '',
-        type: m.type,
-        engine: m.engine,
-        bits: m.bits,
-        primaryBits: m.bits,
-        status: m.status ?? 'stable',
-        repo: m.repo ?? m.id,
-        vram: m.vram,
-        kvCacheMbPer1kTokens: m.kvCacheMbPer1kTokens,
-        tps: m.tps,
-        contextLength: m.defaults?.contextLength,
-        os: ['mac'] as OsPlatform[],
-        isDefault: (m as Record<string, unknown>).default === true,
-        hasVision: false,
-        capabilities: m.capabilities,
-      }]
-    }
-
-    // GGUF model → Linux/Windows entry
-    const ggufEntry: CatalogModel = {
+    const entry: CatalogModel = {
       id: m.id,
       group: m.group,
       family: m.family,
@@ -201,13 +199,13 @@ export async function fetchCatalog(): Promise<{ models: CatalogModel[]; devices:
       kvCacheMbPer1kTokens: m.kvCacheMbPer1kTokens,
       tps: m.tps,
       contextLength: m.defaults?.contextLength,
-      os: ['linux', 'windows'] as OsPlatform[],
+      os: resolveModelPlatforms(m),
       isDefault: (m as Record<string, unknown>).default === true,
       hasVision,
       capabilities: m.capabilities,
     }
 
-    return [ggufEntry]
+    return [entry]
   })
 
   const devices: DeviceInfo[] = [

--- a/site/src/lib/model-filters.ts
+++ b/site/src/lib/model-filters.ts
@@ -1,0 +1,11 @@
+export type TaskChip = 'llm' | 'vision' | 'image' | 'audio'
+
+export interface FilterState {
+  contextMin: number | null
+  task: TaskChip | null
+}
+
+export const EMPTY_FILTERS: FilterState = {
+  contextMin: null,
+  task: null,
+}

--- a/site/src/lib/platform-state.ts
+++ b/site/src/lib/platform-state.ts
@@ -1,0 +1,95 @@
+import type { Platform } from './catalog'
+import { DEFAULT_FRAMEWORK } from './frameworks'
+
+export interface PlatformDraft {
+  selectedModelIds: string[]
+  selectedDeviceId: string | null
+  deviceCount: number
+  selectedVramGb: number | null
+  contextOverride: number | null
+  frameworkId: string
+}
+
+export type PlatformDrafts = Record<Platform, PlatformDraft>
+
+export interface PersistedPlatformState {
+  version: 1
+  activePlatform: Platform
+  drafts: PlatformDrafts
+}
+
+export const PLATFORM_STATE_STORAGE_KEY = 'a2go.platform-state.v1'
+export const DEFAULT_PLATFORM: Platform = 'linux'
+
+export function createEmptyPlatformDraft(frameworkId: string = DEFAULT_FRAMEWORK.id): PlatformDraft {
+  return {
+    selectedModelIds: [],
+    selectedDeviceId: null,
+    deviceCount: 1,
+    selectedVramGb: null,
+    contextOverride: null,
+    frameworkId,
+  }
+}
+
+export function createDefaultPlatformDrafts(frameworkId: string = DEFAULT_FRAMEWORK.id): PlatformDrafts {
+  return {
+    mac: createEmptyPlatformDraft(frameworkId),
+    linux: createEmptyPlatformDraft(frameworkId),
+    windows: createEmptyPlatformDraft(frameworkId),
+    web: createEmptyPlatformDraft(frameworkId),
+  }
+}
+
+function isPlatformDraft(value: unknown): value is PlatformDraft {
+  if (!value || typeof value !== 'object') return false
+  const draft = value as Record<string, unknown>
+  return Array.isArray(draft.selectedModelIds)
+    && (typeof draft.selectedDeviceId === 'string' || draft.selectedDeviceId === null)
+    && typeof draft.deviceCount === 'number'
+    && (typeof draft.selectedVramGb === 'number' || draft.selectedVramGb === null)
+    && (typeof draft.contextOverride === 'number' || draft.contextOverride === null)
+    && typeof draft.frameworkId === 'string'
+}
+
+export function loadPlatformState(): PersistedPlatformState | null {
+  if (typeof window === 'undefined') return null
+
+  try {
+    const raw = window.localStorage.getItem(PLATFORM_STATE_STORAGE_KEY)
+    if (!raw) return null
+
+    const parsed = JSON.parse(raw) as Partial<PersistedPlatformState>
+    if (parsed.version !== 1) return null
+    if (!parsed.activePlatform || !['mac', 'linux', 'windows', 'web'].includes(parsed.activePlatform)) return null
+    if (!parsed.drafts || typeof parsed.drafts !== 'object') return null
+
+    const drafts = parsed.drafts as Partial<PlatformDrafts>
+    if (!isPlatformDraft(drafts.mac) || !isPlatformDraft(drafts.linux) || !isPlatformDraft(drafts.windows) || !isPlatformDraft(drafts.web)) {
+      return null
+    }
+
+    return {
+      version: 1,
+      activePlatform: parsed.activePlatform,
+      drafts: {
+        mac: drafts.mac,
+        linux: drafts.linux,
+        windows: drafts.windows,
+        web: drafts.web,
+      },
+    }
+  } catch {
+    return null
+  }
+}
+
+export function savePlatformState(state: PersistedPlatformState): void {
+  if (typeof window === 'undefined') return
+
+  try {
+    window.localStorage.setItem(PLATFORM_STATE_STORAGE_KEY, JSON.stringify(state))
+  } catch {
+    // Ignore quota and serialization failures so the UI remains usable.
+  }
+}

--- a/site/src/lib/url-state.ts
+++ b/site/src/lib/url-state.ts
@@ -1,4 +1,4 @@
-import type { OsPlatform } from './catalog'
+import type { Platform } from './catalog'
 
 export interface ModelParam {
   repo: string
@@ -6,7 +6,7 @@ export interface ModelParam {
 }
 
 export interface UrlState {
-  os: OsPlatform | null
+  platform: Platform | null
   llm: ModelParam | null
   image: ModelParam | null
   audio: ModelParam | null
@@ -15,9 +15,10 @@ export interface UrlState {
   vram: number | null
   ctx: number | null
   agent: string | null
+  hasState: boolean
 }
 
-const VALID_OS: Set<string> = new Set(['linux', 'windows', 'mac'])
+const VALID_PLATFORMS: Set<string> = new Set(['linux', 'windows', 'mac', 'web'])
 
 const MODEL_ROLES = ['llm', 'image', 'audio'] as const
 
@@ -33,8 +34,8 @@ function parseModelParam(params: URLSearchParams, role: string): ModelParam | nu
 export function parseUrlState(): UrlState {
   const params = new URLSearchParams(window.location.search)
 
-  const osRaw = params.get('os')
-  const os = osRaw && VALID_OS.has(osRaw) ? (osRaw as OsPlatform) : null
+  const platformRaw = params.get('platform') ?? params.get('os')
+  const platform = platformRaw && VALID_PLATFORMS.has(platformRaw) ? (platformRaw as Platform) : null
 
   const vramRaw = params.get('vram')
   const vram = vramRaw ? Number(vramRaw) : null
@@ -45,8 +46,11 @@ export function parseUrlState(): UrlState {
   const deviceCountRaw = params.get('deviceCount')
   const deviceCount = deviceCountRaw ? Number(deviceCountRaw) : null
 
+  const recognizedKeys = ['platform', 'os', 'llm', 'image', 'audio', 'device', 'deviceCount', 'vram', 'ctx', 'agent']
+  const hasState = recognizedKeys.some((key) => params.has(key))
+
   return {
-    os,
+    platform,
     llm: parseModelParam(params, 'llm'),
     image: parseModelParam(params, 'image'),
     audio: parseModelParam(params, 'audio'),
@@ -55,6 +59,7 @@ export function parseUrlState(): UrlState {
     vram: vram && Number.isFinite(vram) ? vram : null,
     ctx: ctx && Number.isFinite(ctx) && ctx >= 16384 ? ctx : null,
     agent: params.get('agent'),
+    hasState,
   }
 }
 
@@ -67,7 +72,7 @@ function syncModelParam(params: URLSearchParams, role: string, model: ModelParam
 export function syncUrlState(state: UrlState): void {
   const params = new URLSearchParams()
 
-  if (state.os) params.set('os', state.os)
+  if (state.platform) params.set('platform', state.platform)
   for (const role of MODEL_ROLES) {
     syncModelParam(params, role, state[role])
   }


### PR DESCRIPTION
## Summary

- Renames `OsPlatform` to `Platform` throughout, adds `'web'` as a new platform variant
- Moves platform selector out of model filters into its own top-level section with a grid layout
- Adds per-platform draft state persistence (localStorage) so switching platforms remembers your selections
- Improves selected model card styling with accent color backgrounds and borders
- Adds `resolveModelPlatforms()` for flexible model-to-platform mapping (supports new `platforms` array field)
- URL state: `?os=` param renamed to `?platform=` with backward compat
- Hides memory/hardware panels when "Web" platform is selected
- Extracts filter types to `model-filters.ts`

## Test plan

- [ ] Verify platform selector renders as a top-level grid section
- [ ] Switch between platforms and confirm draft state (selected models) persists per platform in localStorage
- [ ] Select "Web" platform and confirm memory/hardware panels are hidden and deploy tabs are hidden
- [ ] Verify `?platform=linux` URL param works and `?os=linux` still works for backward compat
- [ ] Check selected model cards show accent color backgrounds and borders
- [ ] Confirm model catalog correctly filters models by platform using `resolveModelPlatforms()`