### PR TITLE
feat(site): redesign hardware selector with brand/device dropdowns

### DIFF
--- a/.changeset/hardware-selector-redesign.md
+++ b/.changeset/hardware-selector-redesign.md
@@ -1,0 +1,7 @@
+---
+"a2go": minor
+---
+
+feat(site): redesign hardware device selector with brand/device dropdowns
+
+Replace the crowded pill-based hardware device list with two clean select dropdowns (brand + device) and an integrated count stepper. Move the hardware section into the sidebar alongside agent and model selection. Add WebGL-based GPU auto-detection with a "detect" button in the section header. Reduce model row height for a more compact catalog.

--- a/site/src/App.tsx
+++ b/site/src/App.tsx
@@ -225,6 +225,12 @@ function App() {
     setSelectedVramGb(null)
   }, [os, modelIdToGroup])
 
+  const handleClearModels = useCallback(() => {
+    setSelectedModelIds(new Set())
+    setOs(null)
+    setContextOverride(null)
+  }, [])
+
   const handleClearAll = useCallback(() => {
     setSelectedModelIds(new Set())
     setOs(null)
@@ -297,10 +303,15 @@ function App() {
         onToggleModel={toggleModel}
         remainingVramMb={remainingVramMb}
         effectiveVramMb={effectiveVramMb}
-        onClearAll={handleClearAll}
-        hasSelections={hasSelections}
+        onClearModels={handleClearModels}
         framework={framework}
         onFrameworkSelect={setFramework}
+        devices={filteredDevices}
+        selectedDevice={selectedDevice}
+        onDeviceSelect={handleDeviceSelect}
+        deviceCount={deviceCount}
+        onDeviceCountChange={handleDeviceCountChange}
+        totalVramMb={totalVramMb}
       />
       <ConfigPanel
         selectedModels={selectedModels}
@@ -308,8 +319,6 @@ function App() {
         selectedDevice={selectedDevice}
         devices={filteredDevices}
         deviceCount={deviceCount}
-        onDeviceCountChange={handleDeviceCountChange}
-        onDeviceSelect={handleDeviceSelect}
         onVramPreset={handleVramPreset}
         onToggleModel={toggleModel}
         onClearAll={handleClearAll}

--- a/site/src/components/ConfigPanel.tsx
+++ b/site/src/components/ConfigPanel.tsx
@@ -1,7 +1,6 @@
 import { useState, useMemo, useEffect } from 'react'
 import SectionHeader from './SectionHeader'
 import CollapsibleSection from './CollapsibleSection'
-import DeviceSelector, { DeviceCountStepper } from './VramLegend'
 import VramGauge, { type VramSegment } from './VramSelector'
 import SelectedModels from './SelectedModels'
 import DeployCard from './DeployOutput'
@@ -43,8 +42,6 @@ export default function ConfigPanel({
   selectedDevice,
   devices,
   deviceCount,
-  onDeviceCountChange,
-  onDeviceSelect,
   onVramPreset,
   onToggleModel,
   onClearAll,
@@ -63,8 +60,6 @@ export default function ConfigPanel({
   selectedDevice: DeviceInfo | null
   devices: DeviceInfo[]
   deviceCount: DeviceCount
-  onDeviceCountChange: (count: DeviceCount) => void
-  onDeviceSelect: (device: DeviceInfo) => void
   onVramPreset: (gb: number) => void
   onToggleModel: (model: CatalogModel) => void
   onClearAll: () => void
@@ -128,44 +123,14 @@ export default function ConfigPanel({
     </span>
   ) : undefined
 
-  const hardwareBadge = selectedDevice ? (
-    <span className="font-mono text-[9px] text-foreground/40">
-      {selectedDevice.name}
-    </span>
-  ) : undefined
-
   return (
     <div className="flex flex-1 min-h-0 flex-col overflow-visible lg:overflow-y-scroll">
       {/* Memory — collapsible on mobile, inline on desktop */}
       <CollapsibleSection title="Memory" badge={memoryBadge}>
-        {/* Desktop: toolbar grid row with Memory + Hardware + Logo */}
+        {/* Desktop: toolbar grid row with Memory + Logo */}
         <div className="hidden lg:block">
           <div className="border-b border-foreground/[0.06]">
-            <div className="grid grid-cols-[1fr_1fr_auto]">
-              {/* Hardware */}
-              <div className="border-r border-foreground/[0.06]">
-                <SectionHeader>
-                  <span className="font-mono text-[10px] font-bold uppercase tracking-[0.2em] text-foreground/70">
-                    Hardware
-                  </span>
-                  <span className="ml-auto flex items-center gap-1.5">
-                    <span className="font-mono text-[9px] font-medium uppercase tracking-widest text-foreground/40">
-                      count
-                    </span>
-                    <DeviceCountStepper count={deviceCount} onChange={onDeviceCountChange} />
-                  </span>
-                </SectionHeader>
-                <div className="px-3 py-2.5">
-                  <DeviceSelector
-                    devices={devices}
-                    selectedDevice={selectedDevice}
-                    onSelect={onDeviceSelect}
-                    deviceCount={deviceCount}
-                    totalVramMb={displayVramGb * 1024}
-                  />
-                </div>
-              </div>
-
+            <div className="grid grid-cols-[1fr_auto]">
               {/* Memory */}
               <div className="border-r border-foreground/[0.06]">
                 <SectionHeader>
@@ -224,27 +189,6 @@ export default function ConfigPanel({
           />
         </div>
       </CollapsibleSection>
-
-      {/* Hardware — collapsible on mobile only (desktop is rendered above inside the grid) */}
-      <div className="lg:hidden">
-        <CollapsibleSection title="Hardware" badge={hardwareBadge}>
-          <div className="flex items-center gap-1 border-b border-foreground/[0.04] px-3 py-1.5">
-            <span className="font-mono text-[8px] uppercase tracking-widest text-foreground/25">
-              count
-            </span>
-            <DeviceCountStepper count={deviceCount} onChange={onDeviceCountChange} />
-          </div>
-          <div className="px-3 py-2.5">
-            <DeviceSelector
-              devices={devices}
-              selectedDevice={selectedDevice}
-              onSelect={onDeviceSelect}
-              deviceCount={deviceCount}
-              totalVramMb={displayVramGb * 1024}
-            />
-          </div>
-        </CollapsibleSection>
-      </div>
 
       {/* Selected Models — sticky header */}
       <div className="sticky top-0 z-10 bg-background border-b border-foreground/[0.06]">

--- a/site/src/components/ModelCatalog.tsx
+++ b/site/src/components/ModelCatalog.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useCallback, useState } from 'react'
+import { useMemo, useCallback, useState, useEffect, useRef } from 'react'
 import { ChevronUp, ChevronDown } from 'lucide-react'
 import CollapsibleSection from './CollapsibleSection'
 import ModelSearch from './ModelSearch'
@@ -6,9 +6,67 @@ import ModelFilters, { type FilterState, type TaskChip, EMPTY_FILTERS } from './
 import CatalogEntryCard from './ModelPicker'
 import SectionHeader from './SectionHeader'
 import FrameworkSelector from './FrameworkSelector'
-import type { CatalogModel, OsPlatform } from '../lib/catalog'
+import DeviceSelector from './VramLegend'
+import type { CatalogModel, DeviceInfo, DeviceCount, OsPlatform } from '../lib/catalog'
 import type { AgentFramework } from '../lib/frameworks'
 import { getFamilyEntrySummary, getVariantForOs, type FamilyEntry } from '../lib/group-models'
+
+// ---------------------------------------------------------------------------
+// GPU detection via WebGL
+// ---------------------------------------------------------------------------
+
+type DetectedBrand = 'nvidia' | 'apple'
+
+interface GpuDetection {
+  renderer: string
+  brand: DetectedBrand | null
+  chipHint: string | null
+}
+
+function detectGpuFromWebGL(): GpuDetection | null {
+  try {
+    const canvas = document.createElement('canvas')
+    const gl = canvas.getContext('webgl') || canvas.getContext('experimental-webgl')
+    if (!gl || !(gl instanceof WebGLRenderingContext)) return null
+    const ext = gl.getExtension('WEBGL_debug_renderer_info')
+    if (!ext) return null
+    const renderer = gl.getParameter(ext.UNMASKED_RENDERER_WEBGL) as string
+    canvas.remove()
+    if (!renderer) return null
+
+    const lower = renderer.toLowerCase()
+    if (lower.includes('nvidia') || lower.includes('geforce') || lower.includes('rtx') || lower.includes('quadro') || lower.includes('tesla')) {
+      return { renderer, brand: 'nvidia', chipHint: renderer.replace(/\/.*$/, '').trim() }
+    }
+    if (lower.includes('apple')) {
+      const m = renderer.match(/Apple\s+(M\d+(?:\s+(?:Pro|Max|Ultra))?)/i)
+      return { renderer, brand: 'apple', chipHint: m ? m[1] : null }
+    }
+    if (typeof navigator !== 'undefined' && /Mac/i.test(navigator.platform ?? '')) {
+      return { renderer, brand: 'apple', chipHint: null }
+    }
+    return { renderer, brand: null, chipHint: null }
+  } catch {
+    return null
+  }
+}
+
+function matchDevice(detection: GpuDetection, devices: DeviceInfo[]): DeviceInfo | null {
+  if (!detection.brand) return null
+  const pool = detection.brand === 'nvidia'
+    ? devices.filter((d) => !d.os.includes('mac'))
+    : devices.filter((d) => d.os.includes('mac'))
+
+  if (detection.brand === 'nvidia') {
+    const lower = detection.renderer.toLowerCase()
+    for (const d of pool) { if (lower.includes(d.name)) return d }
+  } else if (detection.brand === 'apple' && detection.chipHint) {
+    const chip = detection.chipHint.toLowerCase()
+    const hits = pool.filter((d) => d.name.includes(chip))
+    if (hits.length === 1) return hits[0]
+  }
+  return null
+}
 
 type SortColumn = 'name' | 'ctx' | 'tps' | 'memory'
 type SortDirection = 'asc' | 'desc'
@@ -72,10 +130,15 @@ export default function ModelCatalog({
   onToggleModel,
   remainingVramMb,
   effectiveVramMb,
-  onClearAll,
-  hasSelections,
+  onClearModels,
   framework,
   onFrameworkSelect,
+  devices,
+  selectedDevice,
+  onDeviceSelect,
+  deviceCount,
+  onDeviceCountChange,
+  totalVramMb,
 }: {
   familyEntries: FamilyEntry[]
   os: OsPlatform | null
@@ -85,14 +148,45 @@ export default function ModelCatalog({
   onToggleModel: (model: CatalogModel) => void
   remainingVramMb: number
   effectiveVramMb: number
-  onClearAll: () => void
-  hasSelections: boolean
+  onClearModels: () => void
   framework: AgentFramework
   onFrameworkSelect: (fw: AgentFramework) => void
+  devices: DeviceInfo[]
+  selectedDevice: DeviceInfo | null
+  onDeviceSelect: (device: DeviceInfo) => void
+  deviceCount: DeviceCount
+  onDeviceCountChange: (count: DeviceCount) => void
+  totalVramMb: number
 }) {
   const [search, setSearch] = useState("")
   const [filters, setFilters] = useState<FilterState>(EMPTY_FILTERS)
   const [sort, setSort] = useState<SortState>({ column: 'name', direction: 'asc' })
+
+  // GPU detection — runs once on mount, button allows re-apply
+  const autoDetectRan = useRef(false)
+  const [detection, setDetection] = useState<GpuDetection | null>(null)
+
+  useEffect(() => {
+    const result = detectGpuFromWebGL()
+    if (result) setDetection(result)
+  }, [])
+
+  // Auto-apply on mount (once, only if no device already selected from URL)
+  useEffect(() => {
+    if (autoDetectRan.current || !detection || selectedDevice) return
+    autoDetectRan.current = true
+    if (detection.brand) {
+      const matched = matchDevice(detection, devices)
+      if (matched) onDeviceSelect(matched)
+    }
+  }, [detection, devices, selectedDevice, onDeviceSelect])
+
+  const handleDetect = useCallback(() => {
+    const result = detection ?? detectGpuFromWebGL()
+    if (!result?.brand) return
+    const matched = matchDevice(result, devices)
+    if (matched && matched.id !== selectedDevice?.id) onDeviceSelect(matched)
+  }, [detection, devices, selectedDevice, onDeviceSelect])
 
   const toggleSort = useCallback((col: SortColumn) => {
     setSort((prev) => {
@@ -242,14 +336,14 @@ export default function ModelCatalog({
     [os, selectedModelIds, onToggleModel]
   )
 
-  const hasActiveFilters = hasSelections || os !== null || filters.task !== null || filters.contextMin !== null || search !== "" || sort.column !== 'name' || sort.direction !== 'asc'
+  const hasActiveFilters = selectedModels.length > 0 || os !== null || filters.task !== null || filters.contextMin !== null || search !== "" || sort.column !== 'name' || sort.direction !== 'asc'
 
   const handleReset = useCallback(() => {
     setSearch("")
     setFilters(EMPTY_FILTERS)
     setSort({ column: 'name', direction: 'asc' })
-    onClearAll()
-  }, [onClearAll])
+    onClearModels()
+  }, [onClearModels])
 
   const modelsBadge = selectedModels.length > 0 ? (
     <span className="flex h-5 min-w-5 items-center justify-center rounded-full bg-primary/20 px-1.5 font-mono text-[10px] font-bold text-primary">
@@ -267,6 +361,33 @@ export default function ModelCatalog({
           </span>
         </SectionHeader>
         <FrameworkSelector selected={framework} onSelect={onFrameworkSelect} />
+      </div>
+
+      {/* Hardware */}
+      <div className="border-b border-foreground/[0.06]">
+        <SectionHeader>
+          <span className="font-mono text-[10px] font-bold uppercase tracking-[0.2em] text-foreground/70">
+            Hardware
+          </span>
+          {detection?.brand && (
+            <button
+              onClick={handleDetect}
+              className="ml-auto shrink-0 font-mono text-[9px] font-medium lowercase tracking-widest text-foreground/40 transition-colors hover:text-foreground/70"
+            >
+              detect
+            </button>
+          )}
+        </SectionHeader>
+        <div className="px-2 py-2">
+          <DeviceSelector
+            devices={devices}
+            selectedDevice={selectedDevice}
+            onSelect={onDeviceSelect}
+            deviceCount={deviceCount}
+            onDeviceCountChange={onDeviceCountChange}
+            totalVramMb={totalVramMb}
+          />
+        </div>
       </div>
 
       <CollapsibleSection title="Models" badge={modelsBadge} className="lg:flex-1 lg:min-h-0 flex flex-col">

--- a/site/src/components/ModelPicker.tsx
+++ b/site/src/components/ModelPicker.tsx
@@ -57,7 +57,7 @@ export default function CatalogEntryCard({
       }}
       className={cn(
         "group flex w-full cursor-pointer items-center text-left transition-all duration-150",
-        "h-10 px-3 gap-2",
+        "h-8 px-3 gap-2",
         selected
           ? "bg-foreground/[0.07]"
           : "hover:bg-foreground/[0.03]",

--- a/site/src/components/VramLegend.tsx
+++ b/site/src/components/VramLegend.tsx
@@ -1,170 +1,170 @@
-import { useMemo } from 'react'
+import { useState, useEffect, useMemo, useCallback } from 'react'
 import { cn } from '../lib/utils'
 import type { DeviceInfo, DeviceCount } from '../lib/catalog'
 import { formatVram, DEVICE_COUNTS } from '../lib/catalog'
+import { ChevronDown, Minus, Plus } from 'lucide-react'
 
-/** Always format as GB (no TB conversion) — used as invisible spacer for stable width */
-function formatVramGbOnly(mb: number): string {
-  const gb = mb / 1024
-  return `${gb % 1 === 0 ? gb.toFixed(0) : gb.toFixed(1)} gb`
-}
-
-function DeviceButton({
-  device,
-  isSelected,
-  isDeactivated,
-  disabled,
-  effectiveVramMb,
-  maxVramMb,
-  onSelect,
-}: {
-  device: DeviceInfo
-  isSelected: boolean
-  isDeactivated: boolean
-  disabled: boolean
-  effectiveVramMb: number
-  maxVramMb: number
-  onSelect: () => void
-}) {
-  return (
-    <button
-      onClick={() => !disabled && onSelect()}
-      disabled={disabled && !isSelected}
-      className={cn(
-        "flex items-baseline px-1.5 py-0.5 font-mono text-[11px] transition-all duration-150",
-        isSelected
-          ? "bg-foreground/10 text-foreground"
-          : "bg-foreground/[0.03] text-foreground/80 hover:bg-foreground/[0.06] hover:text-foreground",
-        isDeactivated && !disabled && "opacity-30",
-        disabled && !isSelected && "opacity-20 pointer-events-none"
-      )}
-    >
-      <span className="font-semibold uppercase tracking-wide">{device.name}</span>
-      {/* Invisible spacer reserves width for widest possible value; real value overlays it */}
-      <span className="relative ml-1 text-[9px] tabular-nums">
-        <span className="invisible whitespace-nowrap">{formatVramGbOnly(maxVramMb)}</span>
-        <span className="absolute inset-0 whitespace-nowrap text-right text-foreground/60">{formatVram(effectiveVramMb)}</span>
-      </span>
-    </button>
-  )
-}
-
-/** Compact stepper for device count — designed to sit inside a section header. */
-export function DeviceCountStepper({
-  count,
-  onChange,
-}: {
-  count: DeviceCount
-  onChange: (count: DeviceCount) => void
-}) {
-  const min = DEVICE_COUNTS[0]
-  const max = DEVICE_COUNTS[DEVICE_COUNTS.length - 1]
-
-  return (
-    <span className="inline-flex items-center gap-0.5 font-mono text-[9px]">
-      <button
-        onClick={() => count > min && onChange((count - 1) as DeviceCount)}
-        disabled={count <= min}
-        className={cn(
-          "font-medium transition-colors",
-          count <= min
-            ? "text-foreground/10 cursor-not-allowed"
-            : "text-foreground/40 hover:text-foreground/70"
-        )}
-      >
-        −
-      </button>
-      <span className="font-bold tabular-nums text-foreground/70">
-        {count}x
-      </span>
-      <button
-        onClick={() => count < max && onChange((count + 1) as DeviceCount)}
-        disabled={count >= max}
-        className={cn(
-          "font-medium transition-colors",
-          count >= max
-            ? "text-foreground/10 cursor-not-allowed"
-            : "text-foreground/40 hover:text-foreground/70"
-        )}
-      >
-        +
-      </button>
-    </span>
-  )
-}
+type Brand = 'nvidia' | 'apple'
 
 export default function DeviceSelector({
   devices,
   selectedDevice,
   onSelect,
   deviceCount,
+  onDeviceCountChange,
   totalVramMb = 0,
 }: {
   devices: DeviceInfo[]
   selectedDevice: DeviceInfo | null
   onSelect: (device: DeviceInfo) => void
   deviceCount: DeviceCount
+  onDeviceCountChange: (count: DeviceCount) => void
   totalVramMb?: number
 }) {
-  const maxCount = DEVICE_COUNTS[DEVICE_COUNTS.length - 1]
   const { nvidiaDevices, macDevices } = useMemo(() => {
     const nvidia = devices.filter((g) => !g.os.includes('mac')).sort((a, b) => a.vramMb - b.vramMb)
     const mac = devices.filter((g) => g.os.includes('mac')).sort((a, b) => a.vramMb - b.vramMb)
     return { nvidiaDevices: nvidia, macDevices: mac }
   }, [devices])
 
+  const availableBrands = useMemo(() => {
+    const brands: Brand[] = []
+    if (nvidiaDevices.length > 0) brands.push('nvidia')
+    if (macDevices.length > 0) brands.push('apple')
+    return brands
+  }, [nvidiaDevices, macDevices])
+
+  const [brand, setBrand] = useState<Brand | null>(() => {
+    if (selectedDevice) return selectedDevice.os.includes('mac') ? 'apple' : 'nvidia'
+    return null
+  })
+
+  useEffect(() => {
+    if (selectedDevice) {
+      setBrand(selectedDevice.os.includes('mac') ? 'apple' : 'nvidia')
+    }
+  }, [selectedDevice])
+
+  useEffect(() => {
+    if (brand && !availableBrands.includes(brand)) {
+      setBrand(availableBrands.length === 1 ? availableBrands[0] : null)
+    } else if (!brand && availableBrands.length === 1) {
+      setBrand(availableBrands[0])
+    }
+  }, [availableBrands, brand])
+
+  const brandDevices = brand === 'nvidia' ? nvidiaDevices : brand === 'apple' ? macDevices : []
+
+  const handleBrandChange = useCallback((newBrand: Brand | null) => {
+    setBrand(newBrand)
+    if (selectedDevice) {
+      const currentBrand = selectedDevice.os.includes('mac') ? 'apple' : 'nvidia'
+      if (currentBrand !== newBrand) onSelect(selectedDevice)
+    }
+  }, [selectedDevice, onSelect])
+
+  const handleDeviceChange = useCallback((deviceId: string) => {
+    if (deviceId === '') {
+      if (selectedDevice) onSelect(selectedDevice)
+      return
+    }
+    const device = devices.find((d) => d.id === deviceId)
+    if (device && device.id !== selectedDevice?.id) onSelect(device)
+  }, [devices, onSelect, selectedDevice])
+
+  const min = DEVICE_COUNTS[0]
+  const max = DEVICE_COUNTS[DEVICE_COUNTS.length - 1]
+
+  const selectClass = cn(
+    "w-full appearance-none border border-foreground/[0.08] bg-foreground/[0.03]",
+    "h-8 px-2 pr-6 font-mono text-[11px]",
+    "text-foreground/80 transition-all duration-150",
+    "hover:border-foreground/15 hover:bg-foreground/[0.05]",
+    "focus:border-foreground/25 focus:outline-none",
+  )
+
   return (
-    <div className="flex flex-col gap-2.5">
-      {nvidiaDevices.length > 0 && (
-        <div className="flex flex-col gap-2">
-          <span className="font-mono text-[8px] font-bold uppercase tracking-[0.2em] text-foreground/30">
-            NVIDIA
-          </span>
-          <div className="flex flex-wrap gap-1">
-            {nvidiaDevices.map((device) => {
-              const cantFit = totalVramMb > 0 && device.vramMb * deviceCount < totalVramMb
-              const isSelected = selectedDevice?.id === device.id
-              return (
-                <DeviceButton
-                  key={device.id}
-                  device={device}
-                  isSelected={isSelected}
-                  isDeactivated={selectedDevice != null && !isSelected}
-                  disabled={cantFit}
-                  effectiveVramMb={device.vramMb * deviceCount}
-                  maxVramMb={device.vramMb * maxCount}
-                  onSelect={() => onSelect(device)}
-                />
-              )
-            })}
-          </div>
-        </div>
-      )}
-      {macDevices.length > 0 && (
-        <div className="flex flex-col gap-2">
-          <span className="font-mono text-[8px] font-bold uppercase tracking-[0.2em] text-foreground/30">
-            Apple Silicon
-          </span>
-          <div className="flex flex-wrap gap-1">
-            {macDevices.map((device) => {
-              const cantFit = totalVramMb > 0 && device.vramMb * deviceCount < totalVramMb
-              const isSelected = selectedDevice?.id === device.id
-              return (
-                <DeviceButton
-                  key={device.id}
-                  device={device}
-                  isSelected={isSelected}
-                  isDeactivated={selectedDevice != null && !isSelected}
-                  disabled={cantFit}
-                  effectiveVramMb={device.vramMb * deviceCount}
-                  maxVramMb={device.vramMb * maxCount}
-                  onSelect={() => onSelect(device)}
-                />
-              )
-            })}
-          </div>
-        </div>
-      )}
+    <div className="flex items-center gap-1.5">
+      {/* Brand */}
+      <div className="relative flex-1 min-w-0">
+        <select
+          value={brand ?? ''}
+          onChange={(e) => handleBrandChange(e.target.value ? (e.target.value as Brand) : null)}
+          className={cn(selectClass, "font-semibold")}
+        >
+          <option value="">brand?</option>
+          {availableBrands.map((b) => (
+            <option key={b} value={b}>
+              {b === 'nvidia' ? 'NVIDIA' : 'Apple'}
+            </option>
+          ))}
+        </select>
+        <ChevronDown
+          size={10}
+          className="pointer-events-none absolute right-1.5 top-1/2 -translate-y-1/2 text-foreground/25"
+        />
+      </div>
+
+      {/* Device */}
+      <div className="relative flex-[1.4] min-w-0">
+        <select
+          value={selectedDevice?.id ?? ''}
+          onChange={(e) => handleDeviceChange(e.target.value)}
+          disabled={!brand}
+          className={cn(
+            selectClass,
+            !brand && "opacity-25 pointer-events-none",
+          )}
+        >
+          <option value="">device?</option>
+          {brandDevices.map((d) => {
+            const cantFit = totalVramMb > 0 && d.vramMb * deviceCount < totalVramMb
+            return (
+              <option key={d.id} value={d.id} disabled={cantFit}>
+                {d.name} — {formatVram(d.vramMb * deviceCount)}
+              </option>
+            )
+          })}
+        </select>
+        <ChevronDown
+          size={10}
+          className={cn(
+            "pointer-events-none absolute right-1.5 top-1/2 -translate-y-1/2 text-foreground/25",
+            !brand && "opacity-25",
+          )}
+        />
+      </div>
+
+      {/* Count stepper */}
+      <div className="flex items-center shrink-0 border border-foreground/[0.08] bg-foreground/[0.03]">
+        <button
+          onClick={() => deviceCount > min && onDeviceCountChange((deviceCount - 1) as DeviceCount)}
+          disabled={deviceCount <= min}
+          className={cn(
+            "flex items-center justify-center w-8 h-8 transition-colors",
+            deviceCount <= min
+              ? "text-foreground/10 cursor-not-allowed"
+              : "text-foreground/40 hover:text-foreground/70 hover:bg-foreground/[0.05]",
+          )}
+        >
+          <Minus size={14} strokeWidth={2} />
+        </button>
+        <span className="font-mono text-[12px] font-bold tabular-nums text-foreground/70 w-6 text-center">
+          {deviceCount}x
+        </span>
+        <button
+          onClick={() => deviceCount < max && onDeviceCountChange((deviceCount + 1) as DeviceCount)}
+          disabled={deviceCount >= max}
+          className={cn(
+            "flex items-center justify-center w-8 h-8 transition-colors",
+            deviceCount >= max
+              ? "text-foreground/10 cursor-not-allowed"
+              : "text-foreground/40 hover:text-foreground/70 hover:bg-foreground/[0.05]",
+          )}
+        >
+          <Plus size={14} strokeWidth={2} />
+        </button>
+      </div>
     </div>
   )
 }


### PR DESCRIPTION
## Summary

- Replace the crowded pill-based hardware device list with two clean `<select>` dropdowns (brand + device) and an integrated count stepper with larger click targets
- Move the hardware section from the right config panel into the left sidebar, between Agent and Models
- Add WebGL-based GPU auto-detection that pre-selects brand + device on page load, with a "detect" button in the Hardware section header for manual re-trigger
- Separate "reset" (clears models/filters only) from "clear all" (clears everything including hardware)
- Reduce model catalog row height for a more compact listing

## Test plan

- [ ] Verify brand dropdown shows NVIDIA and/or Apple based on the active OS tab filter
- [ ] Verify selecting a brand filters the device dropdown to matching devices
- [ ] Verify device count stepper +/- buttons work and have sufficient click area
- [ ] Verify "detect" button in Hardware header auto-selects brand + device when GPU is detectable
- [ ] Verify "reset" in Models header clears models but preserves hardware selection
- [ ] Verify "clear all" in the right panel clears everything including hardware
- [ ] Verify URL state persists hardware selection across page reloads
- [ ] Verify mobile layout renders hardware section properly in the sidebar