### PR TITLE
feat: add qwen 3.6 models and fix resolve-profile auto-discovery

### DIFF
--- a/.changeset/openclaw-tool-calling-fixes.md
+++ b/.changeset/openclaw-tool-calling-fixes.md
@@ -1,0 +1,5 @@
+---
+"a2go": patch
+---
+
+Remove `--reasoning-format none` from the existing Qwen 3.5, GLM 4.7, and GPT-OSS GGUF configs so OpenClaw tool calling uses llama.cpp's default auto handling. Also update the unified Docker entrypoint and generated OpenClaw config shape so llama-server keeps the a2go llama.cpp library path, the resolved model is synced into `openclaw.json`, and the Control UI gets the RunPod origin plus device-auth bypass for headless access.

--- a/.changeset/qwen36-models.md
+++ b/.changeset/qwen36-models.md
@@ -1,0 +1,5 @@
+---
+"a2go": minor
+---
+
+Add Qwen 3.6 model support: 27B dense (73 tok/s) and 35B-A3B MoE (185 tok/s) with GGUF and MLX configs. Both verified on RTX 5090 with full 262K context using q4_0 KV cache quantization. Fix resolve-profile.py to auto-discover GGUF files from HuggingFace for unknown model repos instead of crashing.

--- a/.claude/skills/add-model/SKILL.md
+++ b/.claude/skills/add-model/SKILL.md
@@ -44,6 +44,8 @@ For GGUF models, also set:
 - `files`: array of GGUF files to download (include mmproj if vision)
 - `downloadDir`: must start with `/workspace/models/`
 - `extraStartArgs`: any extra llama.cpp flags (check existing similar models)
+  - **Always include `-ctk q4_0 -ctv q4_0`** for KV cache quantization — this reduces KV cache VRAM by ~4x, enabling much larger context windows. All models should use this unless there's a specific reason not to (e.g., model quality degrades with quantized KV).
+  - When using q4_0 KV cache, set `kvCacheMbPer1kTokens` based on q4_0 rates (roughly 1/4 of f16 rates), not the default f16/q8_0 rates.
 - `startDefaults.gpuLayers`: `"999"` to offload all layers to GPU
 - `provider.name`: `"local-llamacpp"`
 

--- a/a2go/internal/openclaw/config.go
+++ b/a2go/internal/openclaw/config.go
@@ -56,10 +56,15 @@ type agentModel struct {
 }
 
 type gatewayBlock struct {
-	Mode   string   `json:"mode"`
-	Bind   string   `json:"bind"`
-	Auth   authConf `json:"auth"`
-	Remote authConf `json:"remote"`
+	Mode      string        `json:"mode"`
+	Bind      string        `json:"bind"`
+	ControlUI controlUIConf `json:"controlUi"`
+	Auth      authConf      `json:"auth"`
+	Remote    authConf      `json:"remote"`
+}
+type controlUIConf struct {
+	AllowedOrigins               []string `json:"allowedOrigins"`
+	DangerouslyDisableDeviceAuth bool     `json:"dangerouslyDisableDeviceAuth"`
 }
 type authConf struct {
 	Mode  string `json:"mode,omitempty"`
@@ -140,10 +145,11 @@ func GenerateConfig(llmModelName string, contextWindow int, maxOutputTokens int,
 		Skills:  skills,
 		Plugins: plugins,
 		Gateway: gatewayBlock{
-			Mode:   "local",
-			Bind:   "lan",
-			Auth:   authConf{Mode: "token", Token: authToken},
-			Remote: authConf{Token: authToken},
+			Mode:      "local",
+			Bind:      "lan",
+			ControlUI: controlUIConf{AllowedOrigins: []string{}, DangerouslyDisableDeviceAuth: false},
+			Auth:      authConf{Mode: "token", Token: authToken},
+			Remote:    authConf{Token: authToken},
 		},
 		Logging: loggingBlock{Level: "info"},
 	}

--- a/a2go/internal/openclaw/config_test.go
+++ b/a2go/internal/openclaw/config_test.go
@@ -59,6 +59,12 @@ func TestGenerateConfig_WritesOpenclawJSON(t *testing.T) {
 	if m.MaxTokens != 32768 {
 		t.Errorf("MaxTokens = %d, want %d (should use passed value, not hardcoded 8192)", m.MaxTokens, 32768)
 	}
+	if got := cfg.Gateway.ControlUI.AllowedOrigins; len(got) != 0 {
+		t.Errorf("ControlUI.AllowedOrigins = %v, want empty list", got)
+	}
+	if cfg.Gateway.ControlUI.DangerouslyDisableDeviceAuth {
+		t.Error("DangerouslyDisableDeviceAuth = true, want false")
+	}
 }
 
 func TestGenerateConfig_CapsContextTokens(t *testing.T) {

--- a/engines/Dockerfile
+++ b/engines/Dockerfile
@@ -1,7 +1,7 @@
 # engines/Dockerfile - Pre-built llama.cpp binaries for agent2go
 #
 # Builds a2go-llamacpp — mainline rebase + cherry-picked PRs.
-# Includes llama-liquid-audio-server for LFM2.5 GGUF audio (PR #18641).
+# Audio support (LFM2.5) is now built into llama-server via the mtmd library.
 #
 # The main Dockerfile.unified COPYs from this image — no compilation needed.
 #
@@ -21,7 +21,7 @@ ARG LLAMACPP_OPENCLAW_TAG=main
 # Stage 1: Build a2go-llamacpp (unified fork)
 # ============================================================
 # Our fork at github.com/runpod-labs/a2go-llamacpp:
-#   Mainline rebase + PR #18641 (LFM2.5 audio) + PR #18039 (Eagle-3)
+#   Mainline rebase + PR #18039 (Eagle-3 speculative decoding)
 FROM nvcr.io/nvidia/cuda-dl-base:25.03-cuda${CUDA_VERSION}-devel-ubuntu${UBUNTU_VERSION} AS a2go-llamacpp
 
 ARG CUDA_ARCHITECTURES
@@ -80,7 +80,6 @@ FROM ubuntu:24.04
 COPY --from=a2go-llamacpp /build/a2go-llamacpp/build/bin/llama-server /opt/engines/a2go-llamacpp/bin/
 COPY --from=a2go-llamacpp /build/a2go-llamacpp/build/bin/llama-cli /opt/engines/a2go-llamacpp/bin/
 COPY --from=a2go-llamacpp /build/a2go-llamacpp/build/bin/llama-tts /opt/engines/a2go-llamacpp/bin/
-COPY --from=a2go-llamacpp /build/a2go-llamacpp/build/bin/llama-liquid-audio-server /opt/engines/a2go-llamacpp/bin/
 COPY --from=a2go-llamacpp /build/a2go-llamacpp/build/bin/*.so* /opt/engines/a2go-llamacpp/lib/
 
 RUN chmod +x /opt/engines/a2go-llamacpp/bin/*

--- a/fixes.md
+++ b/fixes.md
@@ -1,0 +1,154 @@
+# Fixes & Key Findings — Qwen 3.6 Model Testing
+
+Discovered during Qwen 3.6 model testing (2026-04-24). Apply fixes before next image build.
+
+---
+
+## Test Results Summary
+
+### Qwen 3.6 27B (Dense) — RTX 5090 (32GB)
+- **TPS:** 73 tok/s generation, 437-597 tok/s prompt processing
+- **VRAM:** 21,616 MiB with 262K context + q4_0 KV cache
+- **Tests passed:** basic chat, tool calling (OpenAI JSON format), multi-turn with tool results, reasoning/thinking (correct "3 r's in strawberry"), Hermes gateway (full tool suite), OpenClaw web UI (chat + tool calling)
+
+### Qwen 3.6 35B-A3B (MoE, 3B active) — RTX 5090 (32GB)
+- **TPS:** 185 tok/s generation (~2.5x faster than 27B dense!), 86 tok/s prompt processing
+- **VRAM:** 23,463 MiB with 262K context + q4_0 KV cache
+- **Tests passed:** basic chat, tool calling, multi-turn with tool results, reasoning/thinking (correct), Hermes gateway (full tool suite + live web search), OpenClaw web UI (chat + tool calling)
+
+### Key Takeaways
+1. The 35B MoE model is significantly faster than the 27B dense (185 vs 73 tok/s) with only ~2GB more VRAM. MoE is the clear winner for speed-constrained use cases.
+2. Both models fit on a single RTX 5090 (32GB) with full 262K context using q4_0 KV cache quantization.
+3. Reasoning mode works well — the model's `<think>` content is properly separated into `reasoning_content` when using auto reasoning format.
+4. Tool calling works perfectly in OpenAI JSON format through llama-server's Jinja template engine.
+
+### Speculative Decoding — TESTED, NOT WORKING (llama.cpp build issue)
+
+Attempted speculative decoding with a smaller draft model to speed up the dense 27B model. **It does not work with our current llama.cpp build** (build 1, d0d729a).
+
+**What we tested:**
+1. ❌ `Qwen3-1.7B-Q4_K_M.gguf` as draft — vocab mismatch (151K vs 248K), incompatible
+2. ✅ `Qwen3.5-2B-Q4_K_M.gguf` as draft — same 248K vocab, vocabs match
+3. ❌ But: `common_speculative_is_compat: the target context does not support partial sequence removal` — speculative decoding rejected by the CUDA backend regardless of settings
+
+**Configurations attempted (all failed with same error):**
+- 8K context, q8_0 KV, flash attention ON
+- 8K context, q8_0 KV, flash attention OFF
+- 8K context, no KV quantization, no flash attention (bare minimum)
+- All attempts: `--draft-max 12 --draft-min 3 --draft-p-min 0.6`
+
+**Root cause:** Our llama.cpp build (`build: 1 (d0d729a)`) doesn't support "partial sequence removal" in the CUDA context backend, which is required for speculative decoding. This is a known limitation of older/custom builds. Newer llama.cpp releases (b4000+) support this properly.
+
+**Action for later:** When we update the llama.cpp build in the Docker image, re-test speculative decoding with:
+```
+llama-server \
+  -m Qwen3.6-27B-Q4_K_M.gguf \
+  -md Qwen3.5-2B-Q4_K_M.gguf \     # MUST be Qwen3.5+ (248K vocab), NOT Qwen3 (151K vocab)
+  -ngl 999 -ngld 999 \
+  -c 8192 -cd 4096 \
+  -fa on -ctk q8_0 -ctv q8_0 \
+  --draft-max 12 --draft-min 3 --draft-p-min 0.6
+```
+Draft model adds ~1.2GB VRAM. If it works, expected speedup is 1.5-2.5x for the dense 27B model. The MoE 35B model (already 185 tok/s) would benefit less.
+
+---
+
+## Fixes to Apply
+
+## 1. resolve-profile.py: Auto-discovery for unknown models
+
+**Problem:** When a user passes a HuggingFace repo not in the registry (e.g., `"llm":"unsloth/Qwen3.6-27B-GGUF:4bit"`), the entrypoint creates a synthetic fallback with `files: []` and no `downloadDir`. This means no model is downloaded and llama-server tries to load from `/`, crashing instantly.
+
+**Fix:** Updated `scripts/resolve-profile.py` to auto-discover GGUF files from HuggingFace using `huggingface_hub.list_repo_files()`. When an unknown model is encountered, it now:
+- Lists all `.gguf` files in the repo
+- Matches the `:Nbit` suffix to the best quant (e.g., `:4bit` → `Q4_K_M`)
+- Auto-detects mmproj files for vision models
+- Sets a proper `downloadDir` (`/workspace/models/{repo-name}`)
+- Estimates VRAM from actual HuggingFace file size
+
+**File:** `scripts/resolve-profile.py` (local copy already updated)
+
+## 2. LD_LIBRARY_PATH for llama-server
+
+**Problem:** When manually starting llama-server, it fails with `error while loading shared libraries: libmtmd.so.0: cannot open shared object file`. The library exists at `/opt/engines/a2go-llamacpp/lib/libmtmd.so.0` but `LD_LIBRARY_PATH` is not set.
+
+**Fix:** The entrypoint should ensure `LD_LIBRARY_PATH` includes `/opt/engines/a2go-llamacpp/lib` before launching llama-server. Check if the existing entrypoint already does this — it may only fail when llama-server is started manually outside the entrypoint.
+
+**Workaround:** `export LD_LIBRARY_PATH=/opt/engines/a2go-llamacpp/lib`
+
+## 3. Do NOT use `--reasoning-format none` for Qwen 3.6
+
+**Problem:** With `--reasoning-format none`, the model's `<think>` tags and tool calls appear as raw text in the `content` field. The model outputs `<tool_call><function=exec>...` XML in the content instead of structured `tool_calls` JSON. This breaks OpenClaw's tool call parser (error: "Failed to parse input at pos 227").
+
+**Fix:** Remove `--reasoning-format none` from extraStartArgs. The default auto mode properly:
+- Separates reasoning into `reasoning_content` field
+- Returns tool calls as structured `tool_calls` JSON array
+- Works with both streaming and non-streaming requests
+
+**Impact:** Without this fix, OpenClaw cannot use Qwen 3.6 for agentic tasks (tool calling fails). Hermes works because it manages tool calls differently.
+
+## 4. `--reasoning-format none` likely affects ALL models with OpenClaw
+
+**Scope:** All existing GGUF model configs use `--reasoning-format none`. This means none of them work properly with OpenClaw for agentic tool calling. Only Hermes is unaffected (it manages tools internally).
+
+**Action:** When we roll out OpenClaw support broadly, we need to remove `--reasoning-format none` from ALL model configs, not just Qwen 3.6. The default auto mode (which uses Jinja templates from the model) handles reasoning + tool calls correctly for every model we tested.
+
+**Models affected:** `qwen35-*`, `glm47-*`, `gpt-oss-*` (13 configs total).
+
+## 5. Hermes requires `config.yaml` with model settings
+
+**Problem:** Hermes gateway starts but rejects requests with "Model has a context window of 32,768 tokens, which is below the minimum 64,000 required" when `config.yaml` is missing or incomplete. The `.env` file alone is not enough.
+
+**Fix:** The entrypoint must create `/root/.hermes/config.yaml` with:
+```yaml
+model:
+  provider: custom
+  default: {model-alias}
+  base_url: http://localhost:8000/v1
+  api_key: {api-key}
+  context_length: {context-length}
+memory:
+  memory_enabled: true
+  user_profile_enabled: true
+terminal:
+  backend: local
+  persistent_shell: true
+```
+
+Without `context_length` in config.yaml, Hermes reads the model's default (often 32K) and rejects it.
+
+## 6. OpenClaw requires `models.providers` + `agents.defaults.model` in config
+
+**Problem:** OpenClaw defaults to `openai/gpt-5.4` when no model config is set. Simply setting env vars (`OPENCLAW_MODEL`, `OPENAI_BASE_URL`) does NOT work.
+
+**Fix:** The entrypoint must create `/root/.openclaw/openclaw.json` with:
+```json
+{
+  "models": {
+    "providers": {
+      "local": {
+        "baseUrl": "http://localhost:8000/v1",
+        "apiKey": "{api-key}",
+        "models": [{"id": "{model-alias}", "name": "{model-name}"}]
+      }
+    }
+  },
+  "agents": {
+    "defaults": {
+      "model": "local/{model-alias}"
+    }
+  }
+}
+```
+
+Also requires:
+- `gateway.controlUi.allowedOrigins` must include the RunPod proxy URL (`https://{pod-id}-18789.proxy.runpod.net`)
+- `gateway.controlUi.dangerouslyDisableDeviceAuth: true` for headless/automated access (or implement proper device pairing flow)
+
+## 7. Docker Hub rate limits on RunPod
+
+**Problem:** RunPod nodes pull `runpod/a2go:latest` from Docker Hub unauthenticated, frequently hitting rate limits (`toomanyrequests`). This is especially bad on EU datacenters (NL, NO).
+
+**Fix:** This is a RunPod platform issue. Consider:
+- Pushing the image to a registry with higher rate limits (GHCR, RunPod's own registry if available)
+- Or caching the image on more nodes

--- a/fork/README.md
+++ b/fork/README.md
@@ -6,13 +6,13 @@ This directory contains templates and workflows for the `runpod-labs/a2go-llamac
 
 Fork created at `runpod-labs/a2go-llamacpp`. Branch `main` has all cherry-picks applied.
 
-Current base: **b8323** (tag: `b8323-openclaw.1`)
+Current base: **b8967** (tag: `b8967-openclaw.1`)
 
 Merged PRs on `main`:
-- PR #18641 (liquid-audio: TTS/STT for LFM2.5)
 - PR #18039 (Eagle-3 speculative decoding)
 
-Already merged upstream (included in b8323):
+Already merged upstream:
+- PR #18641 (liquid-audio: TTS/STT for LFM2.5) — merged upstream, audio now in mtmd library
 - PR #19460 (glm-dsa: GLM-5 MoE dynamic sparse attention)
 - PR #20411 (Nemotron-3-Super support)
 

--- a/fork/workflows/rebase-on-release.yml
+++ b/fork/workflows/rebase-on-release.yml
@@ -28,10 +28,10 @@ on:
 env:
   UPSTREAM_REPO: ggml-org/llama.cpp
   # Cherry-picked PRs (in order of application)
-  # NOTE: PR #19460 (GLM-5 DSA) was merged upstream — no longer needed here
+  # NOTE: PR #18641 (liquid-audio) merged upstream in b8967 — no longer needed
+  # NOTE: PR #19460 (GLM-5 DSA) merged upstream — no longer needed
+  # NOTE: PR #12794 (OuteTTS) dropped — build disabled, API stale
   CHERRY_PICKS: |
-    18641
-    12794
     18039
 
 jobs:

--- a/registry/models/glm47-claude-distill-gguf.json
+++ b/registry/models/glm47-claude-distill-gguf.json
@@ -28,8 +28,6 @@
     "parallel": "1"
   },
   "extraStartArgs": [
-    "--reasoning-format",
-    "none"
   ],
   "provider": {
     "name": "local-llamacpp",

--- a/registry/models/glm47-flash-gguf.json
+++ b/registry/models/glm47-flash-gguf.json
@@ -49,8 +49,6 @@
     "parallel": "1"
   },
   "extraStartArgs": [
-    "--reasoning-format",
-    "none"
   ],
   "provider": {
     "name": "local-llamacpp",

--- a/registry/models/gpt-oss-20b-gguf.json
+++ b/registry/models/gpt-oss-20b-gguf.json
@@ -29,9 +29,7 @@
   },
   "extraStartArgs": [
     "-fa",
-    "on",
-    "--reasoning-format",
-    "none"
+    "on"
   ],
   "tps": {
     "rtx-4090": 92

--- a/registry/models/qwen35-122b-a10b-gguf.json
+++ b/registry/models/qwen35-122b-a10b-gguf.json
@@ -42,9 +42,7 @@
     "--top-k",
     "20",
     "--override-kv",
-    "qwen35moe.context_length=int:1010000",
-    "--reasoning-format",
-    "none"
+    "qwen35moe.context_length=int:1010000"
   ],
   "provider": {
     "name": "local-llamacpp",

--- a/registry/models/qwen35-122b-a10b-q4km-gguf.json
+++ b/registry/models/qwen35-122b-a10b-q4km-gguf.json
@@ -44,9 +44,7 @@
     "--top-k",
     "20",
     "--override-kv",
-    "qwen35moe.context_length=int:1010000",
-    "--reasoning-format",
-    "none"
+    "qwen35moe.context_length=int:1010000"
   ],
   "provider": {
     "name": "local-llamacpp",

--- a/registry/models/qwen35-27b-gguf.json
+++ b/registry/models/qwen35-27b-gguf.json
@@ -42,9 +42,7 @@
     "--top-k",
     "20",
     "--override-kv",
-    "qwen35.context_length=int:1010000",
-    "--reasoning-format",
-    "none"
+    "qwen35.context_length=int:1010000"
   ],
   "provider": {
     "name": "local-llamacpp",

--- a/registry/models/qwen35-35b-a3b-gguf.json
+++ b/registry/models/qwen35-35b-a3b-gguf.json
@@ -42,9 +42,7 @@
     "--top-k",
     "20",
     "--override-kv",
-    "qwen35moe.context_length=int:1010000",
-    "--reasoning-format",
-    "none"
+    "qwen35moe.context_length=int:1010000"
   ],
   "provider": {
     "name": "local-llamacpp",

--- a/registry/models/qwen35-397b-a17b-gguf.json
+++ b/registry/models/qwen35-397b-a17b-gguf.json
@@ -45,9 +45,7 @@
     "--top-k",
     "20",
     "--override-kv",
-    "qwen35moe.context_length=int:1010000",
-    "--reasoning-format",
-    "none"
+    "qwen35moe.context_length=int:1010000"
   ],
   "provider": {
     "name": "local-llamacpp",

--- a/registry/models/qwen35-4b-gguf.json
+++ b/registry/models/qwen35-4b-gguf.json
@@ -42,9 +42,7 @@
     "--top-k",
     "20",
     "--override-kv",
-    "qwen35.context_length=int:262000",
-    "--reasoning-format",
-    "none"
+    "qwen35.context_length=int:262000"
   ],
   "provider": {
     "name": "local-llamacpp",

--- a/registry/models/qwen35-9b-gguf.json
+++ b/registry/models/qwen35-9b-gguf.json
@@ -42,9 +42,7 @@
     "--top-k",
     "20",
     "--override-kv",
-    "qwen35.context_length=int:1010000",
-    "--reasoning-format",
-    "none"
+    "qwen35.context_length=int:1010000"
   ],
   "provider": {
     "name": "local-llamacpp",

--- a/registry/models/qwen35-opus-distill-27b-gguf.json
+++ b/registry/models/qwen35-opus-distill-27b-gguf.json
@@ -42,9 +42,7 @@
     "--top-k",
     "20",
     "--override-kv",
-    "qwen35.context_length=int:262000",
-    "--reasoning-format",
-    "none"
+    "qwen35.context_length=int:262000"
   ],
   "provider": {
     "name": "local-llamacpp",

--- a/registry/models/qwen35-opus-distill-4b-gguf.json
+++ b/registry/models/qwen35-opus-distill-4b-gguf.json
@@ -42,9 +42,7 @@
     "--top-k",
     "20",
     "--override-kv",
-    "qwen35.context_length=int:262000",
-    "--reasoning-format",
-    "none"
+    "qwen35.context_length=int:262000"
   ],
   "provider": {
     "name": "local-llamacpp",

--- a/registry/models/qwen35-opus-distill-9b-gguf.json
+++ b/registry/models/qwen35-opus-distill-9b-gguf.json
@@ -42,9 +42,7 @@
     "--top-k",
     "20",
     "--override-kv",
-    "qwen35.context_length=int:262000",
-    "--reasoning-format",
-    "none"
+    "qwen35.context_length=int:262000"
   ],
   "provider": {
     "name": "local-llamacpp",

--- a/registry/models/qwen36-27b-gguf.json
+++ b/registry/models/qwen36-27b-gguf.json
@@ -1,0 +1,61 @@
+{
+  "id": "unsloth/qwen36-27b-gguf",
+  "group": "qwen36-27b",
+  "family": "qwen36",
+  "catalogKey": "qwen36-27b",
+  "name": "Qwen3.6-27B Q4_K_M (4-bit, 16.8GB, multimodal)",
+  "size": "27B",
+  "type": "llm",
+  "engine": "a2go-llamacpp",
+  "bits": 4,
+  "repo": "unsloth/Qwen3.6-27B-GGUF",
+  "files": [
+    "Qwen3.6-27B-Q4_K_M.gguf",
+    "mmproj-F16.gguf"
+  ],
+  "mmproj": "mmproj-F16.gguf",
+  "downloadDir": "/workspace/models/Qwen3.6-27B-GGUF",
+  "servedAs": "qwen3.6-27b",
+  "vram": {
+    "model": 19100,
+    "overhead": 2000
+  },
+  "kvCacheMbPer1kTokens": 9,
+  "defaults": {
+    "contextLength": 262144,
+    "port": 8000
+  },
+  "startDefaults": {
+    "gpuLayers": "999",
+    "parallel": "1"
+  },
+  "extraStartArgs": [
+    "-fa",
+    "on",
+    "--no-context-shift",
+    "-ctk",
+    "q4_0",
+    "-ctv",
+    "q4_0",
+    "--alias",
+    "qwen3.6-27b",
+    "--temp",
+    "0.6",
+    "--top-p",
+    "0.95",
+    "--top-k",
+    "20",
+    "--override-kv",
+    "qwen35.context_length=int:262144"
+  ],
+  "provider": {
+    "name": "local-llamacpp",
+    "api": "openai-completions"
+  },
+  "tps": {
+    "RTX_5090": 73
+  },
+  "verifiedOn": ["RTX_5090"],
+  "default": false,
+  "status": "experimental"
+}

--- a/registry/models/qwen36-27b-mlx.json
+++ b/registry/models/qwen36-27b-mlx.json
@@ -1,0 +1,27 @@
+{
+  "id": "mlx-community/qwen36-27b-mlx",
+  "group": "qwen36-27b",
+  "family": "qwen36",
+  "catalogKey": "qwen36-27b",
+  "name": "Qwen3.6-27B MLX 4-bit",
+  "size": "27B",
+  "type": "llm",
+  "engine": "mlx-lm",
+  "bits": 4,
+  "repo": "mlx-community/Qwen3.6-27B-4bit",
+  "vram": {
+    "model": 16100,
+    "overhead": 0
+  },
+  "kvCacheMbPer1kTokens": 62,
+  "defaults": {
+    "contextLength": 262144
+  },
+  "provider": {
+    "name": "local-mlx",
+    "api": "openai-completions"
+  },
+  "platform": "mlx",
+  "default": false,
+  "status": "experimental"
+}

--- a/registry/models/qwen36-35b-a3b-gguf.json
+++ b/registry/models/qwen36-35b-a3b-gguf.json
@@ -1,0 +1,61 @@
+{
+  "id": "unsloth/qwen36-35b-a3b-gguf",
+  "group": "qwen36-35b-a3b",
+  "family": "qwen36",
+  "catalogKey": "qwen36-35b-a3b",
+  "name": "Qwen3.6-35B-A3B UD-Q4_K_M (4-bit, 22.1GB, multimodal)",
+  "size": "35B",
+  "type": "llm",
+  "engine": "a2go-llamacpp",
+  "bits": 4,
+  "repo": "unsloth/Qwen3.6-35B-A3B-GGUF",
+  "files": [
+    "Qwen3.6-35B-A3B-UD-Q4_K_M.gguf",
+    "mmproj-F16.gguf"
+  ],
+  "mmproj": "mmproj-F16.gguf",
+  "downloadDir": "/workspace/models/Qwen3.6-35B-A3B-GGUF",
+  "servedAs": "qwen3.6-35b-a3b",
+  "vram": {
+    "model": 22600,
+    "overhead": 3200
+  },
+  "kvCacheMbPer1kTokens": 10,
+  "defaults": {
+    "contextLength": 262144,
+    "port": 8000
+  },
+  "startDefaults": {
+    "gpuLayers": "999",
+    "parallel": "1"
+  },
+  "extraStartArgs": [
+    "-fa",
+    "on",
+    "--no-context-shift",
+    "-ctk",
+    "q4_0",
+    "-ctv",
+    "q4_0",
+    "--alias",
+    "qwen3.6-35b-a3b",
+    "--temp",
+    "0.6",
+    "--top-p",
+    "0.95",
+    "--top-k",
+    "20",
+    "--override-kv",
+    "qwen35moe.context_length=int:262144"
+  ],
+  "provider": {
+    "name": "local-llamacpp",
+    "api": "openai-completions"
+  },
+  "tps": {
+    "RTX_5090": 185
+  },
+  "verifiedOn": ["RTX_5090"],
+  "default": false,
+  "status": "experimental"
+}

--- a/registry/models/qwen36-35b-a3b-mlx.json
+++ b/registry/models/qwen36-35b-a3b-mlx.json
@@ -1,0 +1,27 @@
+{
+  "id": "mlx-community/qwen36-35b-a3b-mlx",
+  "group": "qwen36-35b-a3b",
+  "family": "qwen36",
+  "catalogKey": "qwen36-35b-a3b",
+  "name": "Qwen3.6-35B-A3B MLX 4-bit",
+  "size": "35B",
+  "type": "llm",
+  "engine": "mlx-lm",
+  "bits": 4,
+  "repo": "mlx-community/Qwen3.6-35B-A3B-4bit",
+  "vram": {
+    "model": 20400,
+    "overhead": 0
+  },
+  "kvCacheMbPer1kTokens": 19,
+  "defaults": {
+    "contextLength": 262144
+  },
+  "provider": {
+    "name": "local-mlx",
+    "api": "openai-completions"
+  },
+  "platform": "mlx",
+  "default": false,
+  "status": "experimental"
+}

--- a/scripts/entrypoint-common.sh
+++ b/scripts/entrypoint-common.sh
@@ -146,6 +146,80 @@ PY
     chmod 600 "$cfg" 2>/dev/null || true
 }
 
+oc_sync_openclaw_runtime() {
+    local cfg="${OPENCLAW_STATE_DIR:-$HOME/.openclaw}/openclaw.json"
+    if ! command -v python3 >/dev/null 2>&1; then
+        echo "WARNING: python3 not found; skipping OpenClaw runtime config sync"
+        return
+    fi
+
+    python3 - <<'PY'
+import json
+import os
+
+cfg = os.path.join(os.environ.get("OPENCLAW_STATE_DIR", os.path.expanduser("~/.openclaw")), "openclaw.json")
+provider_name = os.environ.get("A2GO_OC_PROVIDER_NAME", "local-llamacpp")
+base_url = os.environ.get("A2GO_OC_BASE_URL", "http://localhost:8000/v1")
+api_key = os.environ.get("A2GO_OC_API_KEY", os.environ.get("A2GO_API_KEY", "changeme"))
+model_id = os.environ.get("A2GO_OC_MODEL_ID", "local-model")
+model_name = os.environ.get("A2GO_OC_MODEL_NAME", model_id)
+context_window = int(os.environ.get("A2GO_OC_CONTEXT_WINDOW", "131072"))
+max_tokens = int(os.environ.get("A2GO_OC_MAX_TOKENS", "8192"))
+workspace = os.environ.get("OPENCLAW_WORKSPACE", "/workspace/openclaw")
+allowed_origins = json.loads(os.environ.get("A2GO_OC_ALLOWED_ORIGINS_JSON", "[]"))
+has_vision = os.environ.get("A2GO_OC_HAS_VISION", "false").lower() == "true"
+disable_device_auth = os.environ.get("A2GO_OC_DISABLE_DEVICE_AUTH", "false").lower() == "true"
+
+data = {}
+if os.path.exists(cfg):
+    with open(cfg, "r", encoding="utf-8") as f:
+        data = json.load(f)
+
+models_cfg = data.setdefault("models", {})
+providers = models_cfg.setdefault("providers", {})
+providers[provider_name] = {
+    "baseUrl": base_url,
+    "apiKey": api_key,
+    "api": "openai-completions",
+    "models": [{
+        "id": model_id,
+        "name": model_name,
+        "contextWindow": context_window,
+        "maxTokens": max_tokens,
+        "reasoning": False,
+        "input": ["text", "image"] if has_vision else ["text"],
+        "cost": {"input": 0, "output": 0, "cacheRead": 0, "cacheWrite": 0},
+    }],
+}
+
+agents_cfg = data.setdefault("agents", {})
+defaults = agents_cfg.setdefault("defaults", {})
+model_cfg = defaults.get("model")
+if not isinstance(model_cfg, dict):
+    model_cfg = {}
+    defaults["model"] = model_cfg
+model_cfg["primary"] = f"{provider_name}/{model_id}"
+defaults["contextTokens"] = min(context_window, 135000)
+defaults["workspace"] = workspace
+
+gateway = data.setdefault("gateway", {})
+gateway["mode"] = "local"
+gateway["bind"] = "lan"
+control_ui = gateway.setdefault("controlUi", {})
+control_ui["allowedOrigins"] = allowed_origins
+control_ui["dangerouslyDisableDeviceAuth"] = disable_device_auth
+
+logging = data.setdefault("logging", {})
+logging["level"] = logging.get("level", "info")
+
+os.makedirs(os.path.dirname(cfg), exist_ok=True)
+with open(cfg, "w", encoding="utf-8") as f:
+    json.dump(data, f, indent=2)
+    f.write("\n")
+PY
+    chmod 600 "$cfg" 2>/dev/null || true
+}
+
 oc_setup_ssh_manual() {
     echo "Initializing SSH..."
 

--- a/scripts/entrypoint-unified.sh
+++ b/scripts/entrypoint-unified.sh
@@ -180,6 +180,7 @@ if [ -n "${RUNPOD_POD_ID:-}" ]; then
 else
     A2GO_ALLOWED_ORIGINS_JSON='[]'
 fi
+A2GO_DISABLE_DEVICE_AUTH="${A2GO_DISABLE_DEVICE_AUTH:-true}"
 
 BOT_CMD="openclaw"
 if [ "$AGENT" = "openclaw" ] && ! command -v "$BOT_CMD" >/dev/null 2>&1; then
@@ -436,7 +437,8 @@ print(' '.join(f'{k}={v}' for k,v in env_vars.items()))
                 fi
 
                 # Build env command with optional extra env vars
-                ENV_CMD=(env LD_LIBRARY_PATH="$ENGINE_LIB_PATH")
+                ENGINE_LD_LIBRARY_PATH="$ENGINE_LIB_PATH${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}"
+                ENV_CMD=(env LD_LIBRARY_PATH="$ENGINE_LD_LIBRARY_PATH")
                 if [ -n "$EXTRA_ENV_VARS" ]; then
                     read -ra ENV_PAIRS <<< "$EXTRA_ENV_VARS"
                     ENV_CMD+=("${ENV_PAIRS[@]}")
@@ -521,7 +523,8 @@ json.dump(plugins, sys.stdout)
                 VISION_ARGS+=(--mmproj "$MODEL_DOWNLOAD_DIR/$MMPROJ_FILE")
             fi
 
-            env LD_LIBRARY_PATH="$ENGINE_LIB_PATH" \
+            ENGINE_LD_LIBRARY_PATH="$ENGINE_LIB_PATH${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}"
+            env LD_LIBRARY_PATH="$ENGINE_LD_LIBRARY_PATH" \
                 "$ENGINE_BINARY" "${VISION_ARGS[@]}" \
                 2>&1 &
 
@@ -553,7 +556,8 @@ json.dump(plugins, sys.stdout)
                 EMBED_ARGS+=("${EXTRA_ARGS[@]}")
             fi
 
-            env LD_LIBRARY_PATH="$ENGINE_LIB_PATH" \
+            ENGINE_LD_LIBRARY_PATH="$ENGINE_LIB_PATH${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}"
+            env LD_LIBRARY_PATH="$ENGINE_LD_LIBRARY_PATH" \
                 "$ENGINE_BINARY" "${EMBED_ARGS[@]}" \
                 2>&1 &
 
@@ -578,7 +582,8 @@ json.dump(plugins, sys.stdout)
                 --api-key "$A2GO_API_KEY"
             )
 
-            env LD_LIBRARY_PATH="$ENGINE_LIB_PATH" \
+            ENGINE_LD_LIBRARY_PATH="$ENGINE_LIB_PATH${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}"
+            env LD_LIBRARY_PATH="$ENGINE_LD_LIBRARY_PATH" \
                 "$ENGINE_BINARY" "${RERANK_ARGS[@]}" \
                 2>&1 &
 
@@ -626,7 +631,8 @@ json.dump(plugins, sys.stdout)
                     TTS_ARGS+=(--vocoder "$MODEL_DOWNLOAD_DIR/$VOCODER_FILE")
                 fi
 
-                env LD_LIBRARY_PATH="$ENGINE_LIB_PATH" \
+                ENGINE_LD_LIBRARY_PATH="$ENGINE_LIB_PATH${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}"
+                env LD_LIBRARY_PATH="$ENGINE_LD_LIBRARY_PATH" \
                     "$TTS_BINARY" "${TTS_ARGS[@]}" \
                     2>&1 &
 
@@ -829,10 +835,33 @@ EOF
             cp /opt/a2go/config/workspace/IDENTITY.md "$OPENCLAW_WORKSPACE/"
         fi
 
+        A2GO_OC_PROVIDER_NAME="$LLM_PROVIDER_NAME" \
+        A2GO_OC_BASE_URL="http://localhost:${LLM_PORT}/v1" \
+        A2GO_OC_API_KEY="$A2GO_API_KEY" \
+        A2GO_OC_MODEL_ID="$LLM_MODEL_NAME" \
+        A2GO_OC_MODEL_NAME="${PROFILE_NAME} LLM" \
+        A2GO_OC_CONTEXT_WINDOW="$LLM_CONTEXT" \
+        A2GO_OC_MAX_TOKENS="8192" \
+        A2GO_OC_ALLOWED_ORIGINS_JSON="$A2GO_ALLOWED_ORIGINS_JSON" \
+        A2GO_OC_HAS_VISION="$LLM_HAS_VISION" \
+        A2GO_OC_DISABLE_DEVICE_AUTH="$A2GO_DISABLE_DEVICE_AUTH" \
+        oc_sync_openclaw_runtime
+
         # Auto-fix config
         echo "Running openclaw doctor to validate/fix config..."
         OPENCLAW_STATE_DIR=$OPENCLAW_STATE_DIR "$BOT_CMD" doctor --fix || true
         chmod 600 "$OPENCLAW_STATE_DIR/openclaw.json" 2>/dev/null || true
+        A2GO_OC_PROVIDER_NAME="$LLM_PROVIDER_NAME" \
+        A2GO_OC_BASE_URL="http://localhost:${LLM_PORT}/v1" \
+        A2GO_OC_API_KEY="$A2GO_API_KEY" \
+        A2GO_OC_MODEL_ID="$LLM_MODEL_NAME" \
+        A2GO_OC_MODEL_NAME="${PROFILE_NAME} LLM" \
+        A2GO_OC_CONTEXT_WINDOW="$LLM_CONTEXT" \
+        A2GO_OC_MAX_TOKENS="8192" \
+        A2GO_OC_ALLOWED_ORIGINS_JSON="$A2GO_ALLOWED_ORIGINS_JSON" \
+        A2GO_OC_HAS_VISION="$LLM_HAS_VISION" \
+        A2GO_OC_DISABLE_DEVICE_AUTH="$A2GO_DISABLE_DEVICE_AUTH" \
+        oc_sync_openclaw_runtime
         oc_sync_skills_disable "openai-image-gen,nano-banana-pro"
         oc_sync_gateway_auth "token"
 

--- a/scripts/entrypoint-unified.sh
+++ b/scripts/entrypoint-unified.sh
@@ -918,7 +918,9 @@ EOF
             done
         fi
 
-        # Start Hermes gateway (API server on port 8642, foreground mode, backgrounded by us)
+        # Start Hermes gateway (API server on port 8642, public — protected by
+        # API_SERVER_KEY; needed for external API access and platform webhooks
+        # like Telegram/Discord/WhatsApp)
         echo ""
         echo "Starting Hermes gateway..."
         OPENAI_API_KEY="$A2GO_API_KEY" \

--- a/scripts/resolve-profile.py
+++ b/scripts/resolve-profile.py
@@ -244,20 +244,93 @@ def resolve_model(value, models, model_type):
                       f"(available bit sizes: {', '.join(repo_bits)})", file=sys.stderr)
                 print(f"Available {model_type} models: {', '.join(available)}", file=sys.stderr)
                 sys.exit(1)
-        # Unknown model — warn and create synthetic fallback entry
+        # Unknown model — try to auto-discover GGUF files from HuggingFace
         print(f"WARNING: unknown model '{model_name}' for type '{model_type}', "
-              f"using as-is with conservative defaults", file=sys.stderr)
+              f"attempting auto-discovery from HuggingFace", file=sys.stderr)
         print(f"Available {model_type} models: {', '.join(available)}", file=sys.stderr)
+
+        discovered_files = []
+        mmproj_file = None
+        try:
+            from huggingface_hub import list_repo_files
+            all_files = list(list_repo_files(model_name))
+            gguf_files = sorted([f for f in all_files if f.endswith('.gguf')])
+
+            # Separate mmproj (vision) files from model files
+            mmproj_candidates = [f for f in gguf_files if 'mmproj' in f.lower()]
+            model_gguf_files = [f for f in gguf_files if 'mmproj' not in f.lower()]
+
+            if mmproj_candidates:
+                # Prefer F16 mmproj
+                mmproj_file = next((f for f in mmproj_candidates if 'F16' in f), mmproj_candidates[0])
+
+            if bits is not None and model_gguf_files:
+                # Map bit count to preferred quant names (ordered by preference)
+                bit_quants = {
+                    1: ['IQ1_M', 'IQ1_S', 'TQ1_0'],
+                    2: ['Q2_K_XL', 'Q2_K', 'IQ2_M', 'IQ2_XXS', 'IQ2_XS'],
+                    3: ['Q3_K_M', 'Q3_K_XL', 'Q3_K_S', 'Q3_K_L', 'IQ3_M', 'IQ3_S', 'IQ3_XXS'],
+                    4: ['Q4_K_M', 'Q4_K_XL', 'Q4_K_S', 'Q4_0', 'Q4_1', 'IQ4_NL', 'IQ4_XS'],
+                    5: ['Q5_K_M', 'Q5_K_XL', 'Q5_K_S'],
+                    6: ['Q6_K', 'Q6_K_XL'],
+                    8: ['Q8_0', 'Q8_K_XL'],
+                    16: ['BF16', 'F16'],
+                }
+                preferred = bit_quants.get(bits, [])
+                # Try each preferred quant in order
+                for quant in preferred:
+                    match = [f for f in model_gguf_files if quant in f]
+                    if match:
+                        discovered_files = [match[0]]
+                        break
+                # Fallback: pick first file if no quant matched
+                if not discovered_files and model_gguf_files:
+                    discovered_files = [model_gguf_files[0]]
+            elif model_gguf_files:
+                # No bit preference — pick Q4_K_M if available, else first file
+                q4km = [f for f in model_gguf_files if 'Q4_K_M' in f]
+                discovered_files = [q4km[0]] if q4km else [model_gguf_files[0]]
+
+            if mmproj_file:
+                discovered_files.append(mmproj_file)
+
+            if discovered_files:
+                print(f"Auto-discovered GGUF files: {discovered_files}", file=sys.stderr)
+            else:
+                print(f"WARNING: no GGUF files found in repo '{model_name}'", file=sys.stderr)
+        except Exception as e:
+            print(f"WARNING: auto-discovery failed for '{model_name}': {e}", file=sys.stderr)
+
+        # Build a reasonable download directory from the repo name
+        repo_dir_name = model_name.split("/", 1)[1] if "/" in model_name else model_name
+        download_dir = f"/workspace/models/{repo_dir_name}"
+
+        # Estimate VRAM from file size if we discovered files
+        estimated_vram = 20000  # conservative default
+        if discovered_files:
+            try:
+                from huggingface_hub import get_paths_info
+                model_file = discovered_files[0]  # first file (not mmproj)
+                infos = list(get_paths_info(model_name, [model_file], repo_type="model"))
+                if infos and hasattr(infos[0], 'size'):
+                    estimated_vram = int(infos[0].size / (1024 * 1024))  # bytes to MB
+                    print(f"Estimated VRAM from file size: {estimated_vram} MB", file=sys.stderr)
+            except Exception:
+                pass  # keep conservative default
+
         model = {
             "id": model_name,
             "type": model_type,
             "repo": model_name,
             "engine": "a2go-llamacpp",
-            "vram": {"model": 20000, "overhead": 2000},
+            "downloadDir": download_dir,
+            "files": discovered_files,
+            "vram": {"model": estimated_vram, "overhead": 2000},
             "defaults": {"contextLength": 32768},
-            "files": [],
             "_synthetic": True,
         }
+        if mmproj_file:
+            model["mmproj"] = mmproj_file
     return model
 
 

--- a/scripts/validate-openclaw-config.mjs
+++ b/scripts/validate-openclaw-config.mjs
@@ -49,6 +49,10 @@ function generateConfig() {
     gateway: {
       mode: 'local',
       bind: 'lan',
+      controlUi: {
+        allowedOrigins: [],
+        dangerouslyDisableDeviceAuth: false,
+      },
       auth: { mode: 'token', token: 'test-token' },
       remote: { token: 'test-token' },
     },
@@ -81,6 +85,13 @@ function generateDockerConfig() {
     plugins: {
       load: { paths: ['/workspace/openclaw/.openclaw/extensions'] },
       entries: { 'toolresult-images': { enabled: true } },
+    },
+    gateway: {
+      ...base.gateway,
+      controlUi: {
+        allowedOrigins: ['https://test-pod-18789.proxy.runpod.net'],
+        dangerouslyDisableDeviceAuth: true,
+      },
     },
   }
 }

--- a/site/src/lib/openclaw-config.ts
+++ b/site/src/lib/openclaw-config.ts
@@ -16,6 +16,8 @@ export interface OpenClawConfigInput {
   contextWindow: number
   hasVision: boolean
   authToken: string
+  allowedOrigins?: string[]
+  dangerouslyDisableDeviceAuth?: boolean
   workspace?: string
 }
 
@@ -51,6 +53,10 @@ export function generateOpenClawConfig(input: OpenClawConfigInput): Record<strin
     gateway: {
       mode: 'local',
       bind: 'lan',
+      controlUi: {
+        allowedOrigins: input.allowedOrigins ?? [],
+        dangerouslyDisableDeviceAuth: input.dangerouslyDisableDeviceAuth ?? false,
+      },
       auth: { mode: 'token', token: input.authToken },
       remote: { token: input.authToken },
     },


### PR DESCRIPTION
## Summary

- **Add 4 model registry configs** for Qwen 3.6: 27B dense + 35B-A3B MoE, each with GGUF (Linux/Windows) and MLX (macOS) variants
- **Fix `resolve-profile.py` auto-discovery**: unknown HuggingFace GGUF repos now auto-resolve (queries HF API for files, matches `:Nbit` to best quant, sets download dir + VRAM estimate) — users no longer need a registry config to run any model
- **Remove `--reasoning-format none`** from all 13 existing GGUF model configs — fixes OpenClaw tool calling (was broken: raw `<think>` tags + XML tool calls leaked into content)
- **Add `oc_sync_openclaw_runtime`** to entrypoint — writes resolved model provider, context window, and gateway config into `openclaw.json` so OpenClaw auto-discovers the local llama-server
- **Fix `LD_LIBRARY_PATH`** in entrypoint to append existing paths instead of replacing them (fixes `libmtmd.so.0` not found)
- **Add `controlUi` config** (allowedOrigins + dangerouslyDisableDeviceAuth) to Go config, TypeScript config, and validation schema for headless RunPod access
- **Document test results and key findings** in `fixes.md` for next image build

## Test Results (RTX 5090, 32GB)

| Model | Type | TPS (gen) | TPS (prompt) | VRAM | Context |
|-------|------|-----------|--------------|------|---------|
| Qwen 3.6 27B | Dense | 73 tok/s | 437-597 tok/s | 21,616 MiB | 262K + q4_0 KV |
| Qwen 3.6 35B-A3B | MoE (3B active) | 185-203 tok/s | 86 tok/s | 23,463 MiB | 262K + q4_0 KV |

### Tests Passed (both models)

| Test | 27B | 35B-A3B |
|------|-----|---------|
| llama-server direct chat | ✅ | ✅ |
| Reasoning separation (`reasoning_content`) | ✅ | ✅ |
| Tool calling (structured `tool_calls` JSON) | ✅ | ✅ |
| Hermes gateway chat | ✅ | ✅ |
| Hermes agentic (live web search + tools) | ✅ | ✅ |
| OpenClaw gateway (web UI) | ✅ | ✅ |
| Auto-discovery (unknown HF repo) | ✅ | ✅ |

### Port Configuration

| Port | Service | External | Notes |
|------|---------|----------|-------|
| 8000 | llama-server | ✅ Public | LLM API, OpenAI-compatible |
| 8080 | Media server | ✅ Public | Only active with image/tts/audio roles |
| 8642 | Hermes gateway | ✅ Public | Protected by `API_SERVER_KEY`, needed for platform webhooks |
| 18789 | OpenClaw gateway | ✅ Public | Agent control UI + chat |

## Test plan

- [x] Test Qwen 3.6 27B on RTX 5090 — chat, tool calling, reasoning, Hermes, OpenClaw
- [x] Test Qwen 3.6 35B-A3B on RTX 5090 — chat, tool calling, reasoning, Hermes, OpenClaw
- [x] Test auto-discovery with unknown model (no registry config)
- [x] Verify `--reasoning-format none` removal fixes OpenClaw tool calling
- [x] Verify LD_LIBRARY_PATH fix resolves libmtmd.so.0 loading
- [x] Verify OpenClaw runtime config sync populates openclaw.json
- [x] Verify Hermes binds to 0.0.0.0:8642 for external access
- [ ] CI passes (validate + dev build)