### PR TITLE
chore: move domain from a2go.run to a2go.getrunpod.io

### DIFF
--- a/.changeset/move-domain-to-getrunpod.md
+++ b/.changeset/move-domain-to-getrunpod.md
@@ -1,0 +1,5 @@
+---
+"a2go": patch
+---
+
+Move the project domain from `a2go.run` to `a2go.getrunpod.io`. This updates the CLI catalog URL, the registry fetch URL, the GitHub Pages custom domain (CNAME), install scripts, and all documentation/site links to the new Runpod-owned domain.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,5 +1,5 @@
 blank_issues_enabled: false
 contact_links:
   - name: Documentation
-    url: https://a2go.run
+    url: https://a2go.getrunpod.io
     about: Check the docs before opening an issue

--- a/.github/workflows/dev-build.yml
+++ b/.github/workflows/dev-build.yml
@@ -135,7 +135,7 @@ jobs:
 
           ### Install CLI
           \`\`\`bash
-          curl -sSL https://a2go.run/install.sh | bash -s -- --version ${TAG}
+          curl -sSL https://a2go.getrunpod.io/install.sh | bash -s -- --version ${TAG}
           \`\`\`
 
           ### Docker image

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ a2go helps you run open-source AI models on your own hardware — locally, on a 
 
 ## Quick start
 
-1. **Pick models** at [a2go.run](https://a2go.run) — select your GPU and the site shows what fits
+1. **Pick models** at [a2go.getrunpod.io](https://a2go.getrunpod.io) — select your GPU and the site shows what fits
 2. **Read the security guide** — OpenClaw agents can execute shell commands, read/write files, and fetch URLs on your machine. Understand what you're running: [Security Guide](https://trust.openclaw.ai)
 3. **Deploy** — the site generates a ready-to-use command (Docker or MLX)
 4. **Access the UI** — `http://localhost:18789/?token=<A2GO_AUTH_TOKEN>`
@@ -118,7 +118,7 @@ The entrypoint only generates `openclaw.json` if it doesn't exist, so your edits
 
 On a Mac, you don't use Docker. Instead, you run model servers natively using Apple's [MLX](https://github.com/ml-explore/mlx) framework, which is optimized for Apple Silicon.
 
-Select macOS on [a2go.run](https://a2go.run) and the site generates the exact commands for your selected models. Here's what the flow looks like:
+Select macOS on [a2go.getrunpod.io](https://a2go.getrunpod.io) and the site generates the exact commands for your selected models. Here's what the flow looks like:
 
 ```bash
 # 1. Create a virtual environment
@@ -142,7 +142,7 @@ Not all models have MLX variants — the site will tell you which ones do.
 
 ## Resources
 
-- [a2go.run](https://a2go.run) — model configurator
+- [a2go.getrunpod.io](https://a2go.getrunpod.io) — model configurator
 - [Security Guide](https://trust.openclaw.ai) — trust model, access control, hardening
 - [OpenClaw](https://github.com/openclaw/openclaw) — the agent framework
 - [Runpod](https://runpod.io) — GPU cloud

--- a/a2go/cmd/models.go
+++ b/a2go/cmd/models.go
@@ -11,7 +11,7 @@ import (
 	"github.com/runpod-labs/a2go/a2go/internal/catalog"
 )
 
-const catalogURL = "https://a2go.run/v1/catalog.json"
+const catalogURL = "https://a2go.getrunpod.io/v1/catalog.json"
 
 var (
 	flagModelsType    string

--- a/scripts/a2go-registry
+++ b/scripts/a2go-registry
@@ -37,7 +37,7 @@ KV_CACHE_MB_PER_1K_TOKENS = 40
 # ── Registry fetch constants ─────────────────────────────────
 
 DEFAULT_REGISTRY_URL = (
-    "https://a2go.run/v1/catalog.json"
+    "https://a2go.getrunpod.io/v1/catalog.json"
 )
 FETCH_TIMEOUT = 5  # seconds
 CACHE_DIR = Path(os.environ.get("OPENCLAW_STATE_DIR", os.path.expanduser("~/.openclaw"))) / "registry"

--- a/site/public/CNAME
+++ b/site/public/CNAME
@@ -1,1 +1,1 @@
-a2go.run
+a2go.getrunpod.io

--- a/site/public/install.ps1
+++ b/site/public/install.ps1
@@ -1,5 +1,5 @@
 # Install a2go CLI for Windows
-# Usage: irm https://a2go.run/install.ps1 | iex
+# Usage: irm https://a2go.getrunpod.io/install.ps1 | iex
 #        .\install.ps1 -Version dev-feat-foo
 
 param(

--- a/site/public/install.sh
+++ b/site/public/install.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # Install the a2go CLI binary.
-# Usage: curl -sSL https://a2go.run/install.sh | bash
-#        curl -sSL https://a2go.run/install.sh | bash -s -- --version dev-feat-foo
+# Usage: curl -sSL https://a2go.getrunpod.io/install.sh | bash
+#        curl -sSL https://a2go.getrunpod.io/install.sh | bash -s -- --version dev-feat-foo
 set -euo pipefail
 
 VERSION_TAG=""

--- a/site/src/components/DeployOutput.tsx
+++ b/site/src/components/DeployOutput.tsx
@@ -157,8 +157,8 @@ function buildCliCommand(
   contextOverride?: number | null,
 ): { install: string; doctor: string; run: string } {
   const install = platform === 'windows'
-    ? 'irm https://a2go.run/install.ps1 | iex'
-    : 'curl -sSL https://a2go.run/install.sh | bash'
+    ? 'irm https://a2go.getrunpod.io/install.ps1 | iex'
+    : 'curl -sSL https://a2go.getrunpod.io/install.sh | bash'
 
   const doctor = 'a2go doctor'
 

--- a/skills/a2go/SKILL.md
+++ b/skills/a2go/SKILL.md
@@ -86,4 +86,4 @@ Env vars: `A2GO_AUTH_TOKEN` (gateway auth), `A2GO_API_KEY` (LLM API auth).
 ## Notes
 
 - **Mac/Apple Silicon:** `a2go run` runs natively via MLX (no Docker). Wandler models also work on Mac.
-- **Browse models visually:** https://a2go.run
+- **Browse models visually:** https://a2go.getrunpod.io

--- a/templates/runpod/readme.md
+++ b/templates/runpod/readme.md
@@ -19,7 +19,7 @@ Replace `<pod-id>` with your pod ID from the Runpod dashboard.
 
 ### 1. Pick your models
 
-Go to [a2go.run](https://a2go.run), select your GPU, and choose the models you want to run. The site shows what fits your VRAM and generates the configuration for you.
+Go to [a2go.getrunpod.io](https://a2go.getrunpod.io), select your GPU, and choose the models you want to run. The site shows what fits your VRAM and generates the configuration for you.
 
 ### 2. Set the environment variables
 
@@ -27,7 +27,7 @@ Before deploying, fill in these environment variables:
 
 | Variable | What to put in | Why it's needed |
 |----------|---------------|-----------------|
-| `A2GO_CONFIG` | Paste the JSON from [a2go.run](https://a2go.run). This tells the pod which models to download and run. | Configures which LLM, image, and audio models to load |
+| `A2GO_CONFIG` | Paste the JSON from [a2go.getrunpod.io](https://a2go.getrunpod.io). This tells the pod which models to download and run. | Configures which LLM, image, and audio models to load |
 | `A2GO_AUTH_TOKEN` | A secure password you choose (e.g. `my-secret-token-123`). **Do not leave as `changeme`.** | Authenticates the web UI and agent gateway (OpenClaw / Hermes). Anyone with this token can access your pod. |
 | `A2GO_API_KEY` | A secure API key you choose (e.g. `sk-my-secret-key`). **Do not leave as `changeme`.** | Secures the LLM server. Used both by the agent internally (to talk to the local LLM) and for external API access (`/v1/chat/completions`) |
 

--- a/web/app.js
+++ b/web/app.js
@@ -428,7 +428,7 @@ function NotConfiguredSection({ services, currentLlm }) {
           h("div", { className: "unconfigured-role" }, ROLE_LABELS[role]),
           h("div", { className: "unconfigured-hint" },
             "Select a model on ",
-            h("a", { href: "https://a2go.run", target: "_blank", rel: "noopener", style: { color: "var(--primary)" } }, "a2go.run"),
+            h("a", { href: "https://a2go.getrunpod.io", target: "_blank", rel: "noopener", style: { color: "var(--primary)" } }, "a2go.getrunpod.io"),
             " or set ",
             h("code", null, "A2GO_CONFIG"),
             " on your pod:",


### PR DESCRIPTION
## What

Migrates the project off the personal domain **a2go.run** onto the Runpod-owned **a2go.getrunpod.io**. Pure find-and-replace of the domain across code, config, and docs (12 files + changeset).

| Area | File(s) |
|------|---------|
| GitHub Pages custom domain | `site/public/CNAME` |
| CLI catalog URL | `a2go/cmd/models.go` |
| Registry fetch URL | `scripts/a2go-registry` |
| Site footer link | `web/app.js` |
| Install commands (UI) | `site/src/components/DeployOutput.tsx` |
| Install scripts (usage headers) | `site/public/install.sh`, `site/public/install.ps1` |
| Dev-build install URL | `.github/workflows/dev-build.yml` |
| Issue template docs link | `.github/ISSUE_TEMPLATE/config.yml` |
| Docs | `README.md`, `templates/runpod/readme.md`, `skills/a2go/SKILL.md` |

`CHANGELOG.md` keeps one historical `a2go.run` mention (a past release note) — intentionally left as-is.

## Verification

- `go build ./...` and `go vet ./...` → pass
- `tsc -b` (site) → pass
- ESLint: 5 pre-existing errors in `SelectedModels.tsx` (untouched by this PR)

## ⚠️ Hard cutover — coordinate merge with DNS + Pages

`a2go.run` stops working the moment the Pages custom domain switches. This PR's `CNAME` file sets the new custom domain to `a2go.getrunpod.io` on deploy. To avoid downtime:

1. **First** add the Cloudflare DNS record: `a2go.getrunpod.io` CNAME → `runpod-labs.github.io`
2. **Then** merge this PR (the deploy updates the Pages custom domain automatically via the CNAME file)

## Out of scope (human verification)

- Confirm `DOCKERHUB_USERNAME` / `DOCKERHUB_TOKEN` repo/org secrets are a Runpod-owned org token (not the personal one), and pushes still work.
- Runpod Hub template `4hgezzzadd` ownership — **confirmed Runpod-owned, no action.**